### PR TITLE
Allow for a null endpoint name

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Persisters\When_using_AzureStorageSagaGuard.cs" />
     <Compile Include="Persisters\When_using_AzureSubscriptionStorageGuard.cs" />
     <Compile Include="Subscriptions\SuscriptionTestHelper.cs" />
+    <Compile Include="Subscriptions\When_subscribing_with_null_endpoint.cs" />
     <Compile Include="Subscriptions\When_subscribing.cs" />
     <Compile Include="Subscriptions\When_unsubscribing.cs" />
     <Compile Include="Timeouts\TestHelper.cs" />

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Subscriptions/When_subscribing_with_null_endpoint.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Subscriptions/When_subscribing_with_null_endpoint.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Subscriptions
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Routing;
+    using Unicast.Subscriptions;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureStoragePersistence")]
+    public class When_subscribing_with_null_endpoint
+    {
+        [SetUp]
+        public void Setup()
+        {
+            SubscriptionTestHelper.PerformStorageCleanup();
+        }
+
+        [Test]
+        public async Task ensure_that_the_subscription_is_persisted()
+        {
+            var persister = SubscriptionTestHelper.CreateAzureSubscriptionStorage();
+            var messageType = new MessageType(typeof(TestMessage));
+            var messageTypes = new[]
+            {
+                messageType
+            };
+
+            await persister.Subscribe(new Subscriber("address://test-queue", null), messageType, null);
+
+            var subscribers = await persister.GetSubscriberAddressesForMessage(messageTypes, null);
+
+            Assert.That(subscribers.Count(), Is.EqualTo(1));
+
+            var subscription = subscribers.ToArray()[0];
+            Assert.That(subscription.TransportAddress, Is.EqualTo("address://test-queue"));
+            Assert.That(subscription.Endpoint.ToString(), Is.Null);
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Subscriptions/When_subscribing_with_null_endpoint.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Subscriptions/When_subscribing_with_null_endpoint.cs
@@ -2,7 +2,6 @@
 {
     using System.Linq;
     using System.Threading.Tasks;
-    using Routing;
     using Unicast.Subscriptions;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
     using NUnit.Framework;

--- a/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureSubscriptionStorage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureSubscriptionStorage.cs
@@ -56,7 +56,7 @@
                 {
                     RowKey = EncodeTo64(subscriber.TransportAddress),
                     PartitionKey = messageType.ToString(),
-                    EndpointName = subscriber.Endpoint.ToString()
+                    EndpointName = subscriber.Endpoint?.ToString()
                 };
 
                 var operation = TableOperation.Insert(subscription);
@@ -96,7 +96,7 @@
         /// <summary>
         /// Returns the subscription address based on message type
         /// </summary>
-        /// <param name="messageTypes">Types of messages that subscription addresses should sbe found for</param>
+        /// <param name="messageTypes">Types of messages that subscription addresses should be found for</param>
         /// <param name="context">The current pipeline context</param>
         /// <returns>Subscription addresses that were found for the provided messageTypes</returns>
         public async Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context)


### PR DESCRIPTION
Connects with #41 

V5 endpoints won't have an endpoint name stored with the subscription so to accommodate the upgrade path, we should allow for this in V6.

NOTE: This is a finished PR but marked as WIP because it should be merged AFTER #66.