### PR TITLE
Saga completion should remove all the created entities

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/ConfigureAzureStoragePersistence.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/ConfigureAzureStoragePersistence.cs
@@ -8,7 +8,7 @@ public class ConfigureEndpointAzureStoragePersistence : IConfigureEndpointTestEx
 {
     public Task Configure(string endpointName, EndpointConfiguration config, RunSettings settings)
     {
-        var connectionString = Environment.GetEnvironmentVariable("AzureStoragePersistence.ConnectionString");
+        var connectionString = GetConnectionString();
         config.UsePersistence<AzureStoragePersistence, StorageType.Subscriptions>().ConnectionString(connectionString);
         config.UsePersistence<AzureStoragePersistence, StorageType.Sagas>().ConnectionString(connectionString);
         config.UsePersistence<AzureStoragePersistence, StorageType.Timeouts>().ConnectionString(connectionString);
@@ -19,5 +19,10 @@ public class ConfigureEndpointAzureStoragePersistence : IConfigureEndpointTestEx
     Task IConfigureEndpointTestExecution.Cleanup()
     {
         return Task.FromResult(0);
+    }
+
+    public static string GetConnectionString()
+    {
+        return Environment.GetEnvironmentVariable("AzureStoragePersistence.ConnectionString");
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/Extensions.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/Extensions.cs
@@ -1,0 +1,39 @@
+﻿namespace NServiceBus.Persistence.AzureStorage.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using Microsoft.WindowsAzure.Storage.Table;
+
+    public static class Extensions
+    {
+        public static async Task DeleteAllEntities(this CloudTable table)
+        {
+            TableQuerySegment<DynamicTableEntity> segment = null;
+
+            while (segment == null || segment.ContinuationToken != null)
+            {
+                segment = await table.ExecuteQuerySegmentedAsync(new TableQuery().Take(100), segment?.ContinuationToken);
+                foreach (var entity in segment.Results)
+                {
+                    await table.ExecuteAsync(TableOperation.Delete(entity));
+                }
+            }
+        }
+
+        public static async Task<int> CountAllEntities(this CloudTable table)
+        {
+            TableQuerySegment<DynamicTableEntity> segment = null;
+
+            var count = 0;
+            while (segment == null || segment.ContinuationToken != null)
+            {
+                segment = await table.ExecuteQuerySegmentedAsync(new TableQuery().Take(100), segment?.ContinuationToken);
+                if (segment != null)
+                {
+                    count += segment.Results.Count;
+                }
+            }
+
+            return count;
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/NServiceBus.Persistence.AzureStorage.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/NServiceBus.Persistence.AzureStorage.AcceptanceTests.csproj
@@ -92,6 +92,7 @@
   <ItemGroup>
     <Compile Include="ConfigureEndpointAzureStorageQueueTransport.cs" />
     <Compile Include="ConfigureScenariosForAzureStorageQueueTransport.cs" />
+    <Compile Include="Extensions.cs" />
     <Compile Include="Infrastructure\EndpointTemplates\ConfigureEndpointMsmqTransport.cs" />
     <Compile Include="Infrastructure\EndpointTemplates\ConfigureExtensions.cs" />
     <Compile Include="Infrastructure\EndpointTemplates\DefaultPublisher.cs" />
@@ -134,6 +135,7 @@
     <Compile Include="Sagas\When_saga_has_a_non_empty_constructor.cs" />
     <Compile Include="Sagas\When_saga_has_duplicate_instances.cs" />
     <Compile Include="Sagas\When_saga_id_changed.cs" />
+    <Compile Include="Sagas\When_saga_is_completed.cs" />
     <Compile Include="Sagas\When_saga_is_mapped_to_complex_expression.cs" />
     <Compile Include="Sagas\When_saga_is_started_by_two_types_of_messages.cs" />
     <Compile Include="Sagas\When_sending_from_a_saga_handle.cs" />

--- a/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/Sagas/When_saga_is_completed.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/Sagas/When_saga_is_completed.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTests;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NServiceBus.Persistence.AzureStorage.AcceptanceTests;
+using NUnit.Framework;
+
+public class When_saga_is_completed : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Entities_should_be_removed()
+    {
+        var account = CloudStorageAccount.Parse(ConfigureEndpointAzureStoragePersistence.GetConnectionString());
+        var name = typeof(StartComplete.RemovingSecondaryIndexState).Name;
+        var table = account.CreateCloudTableClient().GetTableReference(name);
+        await table.CreateIfNotExistsAsync().ConfigureAwait(false);
+        await table.DeleteAllEntities();
+
+        var guid = Guid.NewGuid().ToString();
+
+        await Scenario.Define<Context>()
+            .WithEndpoint<ReceiverWithSagas>(b => b.When(async session =>
+            {
+                await session.SendLocal(new Start
+                {
+                    OrderId = guid
+                });
+                await session.SendLocal(new Complete
+                {
+                    OrderId = guid
+                });
+            }))
+            .Done(c => c.Completed)
+            .Run().ConfigureAwait(false);
+
+        var count = await table.CountAllEntities();
+        Assert.AreEqual(0, count);
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool Completed { get; set; }
+    }
+
+    public class ReceiverWithSagas : EndpointConfigurationBuilder
+    {
+        public ReceiverWithSagas()
+        {
+            EndpointSetup<DefaultServer>(cfg => cfg.LimitMessageProcessingConcurrencyTo(1));
+        }
+    }
+
+    public class StartComplete : Saga<StartComplete.RemovingSecondaryIndexState>,
+        IAmStartedByMessages<Start>,
+        IHandleMessages<Complete>
+    {
+        public Context Context { get; set; }
+
+        public Task Handle(Start message, IMessageHandlerContext context)
+        {
+            Data.OrderId = message.OrderId;
+            return Task.FromResult(0);
+        }
+
+        public Task Handle(Complete message, IMessageHandlerContext context)
+        {
+            MarkAsComplete();
+            Context.Completed = true;
+            return Task.FromResult(0);
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RemovingSecondaryIndexState> mapper)
+        {
+            mapper.ConfigureMapping<Start>(m => m.OrderId)
+                .ToSaga(s => s.OrderId);
+            mapper.ConfigureMapping<Complete>(m => m.OrderId)
+                .ToSaga(s => s.OrderId);
+        }
+
+        public class RemovingSecondaryIndexState : IContainSagaData
+        {
+            public virtual string OrderId { get; set; }
+            public virtual Guid Id { get; set; }
+            public virtual string Originator { get; set; }
+            public virtual string OriginalMessageId { get; set; }
+        }
+    }
+
+    public class Start : ICommand
+    {
+        public string OrderId { get; set; }
+    }
+
+    public class Complete : ICommand
+    {
+        public string OrderId { get; set; }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/Sagas/When_saga_is_started_by_two_types_of_messages.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/Sagas/When_saga_is_started_by_two_types_of_messages.cs
@@ -36,7 +36,7 @@
                     }
                 }))
                 .Done(c => c.CompletedIds.OrderBy(s => s).ToArray().Intersect(guids).Count() == expectedNumberOfCreatedSagas)
-                .Run().ConfigureAwait(false);
+                .Run(TimeSpan.FromMinutes(3)).ConfigureAwait(false);
 
             CollectionAssert.AreEquivalent(guids, context.CompletedIds.OrderBy(s => s).ToArray());
         }

--- a/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/Sagas/When_saga_is_started_by_two_types_of_messages.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/Sagas/When_saga_is_started_by_two_types_of_messages.cs
@@ -6,8 +6,8 @@
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using EndpointTemplates;
     using Config;
+    using EndpointTemplates;
     using Features;
     using NUnit.Framework;
 
@@ -43,7 +43,6 @@
 
         public class Context : ScenarioContext
         {
-            ConcurrentDictionary<string, string> completed = new ConcurrentDictionary<string, string>();
             public int CompletedIdsCount => completed.Count;
             public IEnumerable<string> CompletedIds => completed.Keys;
 
@@ -51,6 +50,8 @@
             {
                 completed.AddOrUpdate(orderId, orderId, (o1, o2) => o1);
             }
+
+            ConcurrentDictionary<string, string> completed = new ConcurrentDictionary<string, string>();
         }
 
         public class ReceiverWithSagas : EndpointConfigurationBuilder

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/App_Packages/ApiApprover.3.0.1/PublicApiGenerator.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/App_Packages/ApiApprover.3.0.1/PublicApiGenerator.cs
@@ -1,20 +1,21 @@
-﻿using System;
-using System.CodeDom;
-using System.CodeDom.Compiler;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using Microsoft.CSharp;
-using Mono.Cecil;
-using Mono.Cecil.Rocks;
-using TypeAttributes = System.Reflection.TypeAttributes;
-
-// ReSharper disable CheckNamespace
+﻿ // ReSharper disable CheckNamespace
 // ReSharper disable BitwiseOperatorOnEnumWithoutFlags
+
 namespace ApiApprover
 {
+    using System;
+    using System.CodeDom;
+    using System.CodeDom.Compiler;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using Microsoft.CSharp;
+    using Mono.Cecil;
+    using Mono.Cecil.Rocks;
+    using TypeAttributes = System.Reflection.TypeAttributes;
+
     public static class CecilEx
     {
         public static IEnumerable<IMemberDefinition> GetMembers(this TypeDefinition type)
@@ -128,7 +129,7 @@ namespace ApiApprover
             }
             else if (memberInfo is EventDefinition)
             {
-                typeDeclaration.Members.Add(GenerateEvent((EventDefinition)memberInfo));
+                typeDeclaration.Members.Add(GenerateEvent((EventDefinition) memberInfo));
             }
             else if (memberInfo is FieldDefinition)
             {
@@ -192,7 +193,7 @@ namespace ApiApprover
                 IsClass = publicType.IsClass,
                 IsEnum = publicType.IsEnum,
                 IsInterface = publicType.IsInterface,
-                IsStruct = publicType.IsValueType && !publicType.IsPrimitive && !publicType.IsEnum,
+                IsStruct = publicType.IsValueType && !publicType.IsPrimitive && !publicType.IsEnum
             };
 
             if (declaration.IsInterface && publicType.BaseType != null)
@@ -220,7 +221,7 @@ namespace ApiApprover
             // Fields should be in defined order for an enum
             var fields = !publicType.IsEnum
                 ? publicType.Fields.OrderBy(f => f.Name)
-                : (IEnumerable<FieldDefinition>)publicType.Fields;
+                : (IEnumerable<FieldDefinition>) publicType.Fields;
             foreach (var field in fields)
                 AddMemberToTypeDeclaration(declaration, field);
 
@@ -244,7 +245,7 @@ namespace ApiApprover
             {
                 Attributes = MemberAttributes.Public,
                 CustomAttributes = CreateCustomAttributes(publicType),
-                ReturnType = CreateCodeTypeReference(invokeMethod.ReturnType),
+                ReturnType = CreateCodeTypeReference(invokeMethod.ReturnType)
             };
 
             // CodeDOM. No support. Return type attributes.
@@ -355,7 +356,10 @@ namespace ApiApprover
                 var attribute = GenerateCodeAttributeDeclaration(codeTypeModifier, customAttribute);
                 var declaration = new CodeTypeDeclaration("DummyClass")
                 {
-                    CustomAttributes = new CodeAttributeDeclarationCollection(new[] { attribute }),
+                    CustomAttributes = new CodeAttributeDeclarationCollection(new[]
+                    {
+                        attribute
+                    })
                 };
                 using (var writer = new StringWriter())
                 {
@@ -364,30 +368,6 @@ namespace ApiApprover
                 }
             }
         }
-
-        private static readonly HashSet<string> SkipAttributeNames = new HashSet<string>
-        {
-            "System.CodeDom.Compiler.GeneratedCodeAttribute",
-            "System.ComponentModel.EditorBrowsableAttribute",
-            "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
-            "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
-            "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
-            "System.Runtime.CompilerServices.ExtensionAttribute",
-            "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
-            "System.Reflection.DefaultMemberAttribute",
-            "System.Diagnostics.DebuggableAttribute",
-            "System.Diagnostics.DebuggerNonUserCodeAttribute",
-            "System.Diagnostics.DebuggerStepThroughAttribute",
-            "System.Reflection.AssemblyCompanyAttribute",
-            "System.Reflection.AssemblyConfigurationAttribute",
-            "System.Reflection.AssemblyCopyrightAttribute",
-            "System.Reflection.AssemblyDescriptionAttribute",
-            "System.Reflection.AssemblyFileVersionAttribute",
-            "System.Reflection.AssemblyInformationalVersionAttribute",
-            "System.Reflection.AssemblyProductAttribute",
-            "System.Reflection.AssemblyTitleAttribute",
-            "System.Reflection.AssemblyTrademarkAttribute"
-        };
 
         private static bool ShouldIncludeAttribute(CustomAttribute attribute)
         {
@@ -425,32 +405,32 @@ namespace ApiApprover
                     // I'd rather use the above, as it's just using the CodeDOM, but it puts
                     // brackets around each CodeBinaryOperatorExpression
                     var flags = from f in type.Fields
-                                where f.Constant != null
-                                let v = Convert.ToInt64(f.Constant)
-                                where v == 0 || (originalValue & v) != 0
-                                select type.FullName + "." + f.Name;
+                        where f.Constant != null
+                        let v = Convert.ToInt64(f.Constant)
+                        where v == 0 || (originalValue & v) != 0
+                        select type.FullName + "." + f.Name;
                     return new CodeSnippetExpression(flags.Aggregate((current, next) => current + " | " + next));
                 }
 
                 var allFlags = from f in type.Fields
-                               where f.Constant != null
-                               let v = Convert.ToInt64(f.Constant)
-                               where v == originalValue
-                               select new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(CreateCodeTypeReference(type)), f.Name);
+                    where f.Constant != null
+                    let v = Convert.ToInt64(f.Constant)
+                    where v == originalValue
+                    select new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(CreateCodeTypeReference(type)), f.Name);
                 return allFlags.FirstOrDefault();
             }
 
             if (type.FullName == "System.Type" && value is TypeReference)
             {
-                return new CodeTypeOfExpression(CreateCodeTypeReference((TypeReference)value));
+                return new CodeTypeOfExpression(CreateCodeTypeReference((TypeReference) value));
             }
 
             if (value is string)
             {
                 // CodeDOM outputs a verbatim string. Any string with \n is treated as such, so normalise
                 // it to make it easier for comparisons
-                value = Regex.Replace((string)value, @"\n", "\\n");
-                value = Regex.Replace((string)value, @"\r\n|\r\\n", "\\r\\n");
+                value = Regex.Replace((string) value, @"\n", "\\n");
+                value = Regex.Replace((string) value, @"\r\n|\r\\n", "\\r\\n");
             }
 
             return new CodePrimitiveExpression(value);
@@ -486,7 +466,7 @@ namespace ApiApprover
                 Name = member.Name,
                 Attributes = GetMethodAttributes(member),
                 CustomAttributes = CreateCustomAttributes(member),
-                ReturnType = returnType,
+                ReturnType = returnType
             };
             PopulateCustomAttributes(member.MethodReturnType, method.ReturnTypeCustomAttributes);
             PopulateGenericParameters(member, method.TypeParameters);
@@ -584,8 +564,8 @@ namespace ApiApprover
             // in any of the interfaces that we implement
             if (typeDefinition.IsInterface)
             {
-                var interfaceMethods = from @interfaceReference in typeDefinition.Interfaces
-                    let interfaceDefinition = @interfaceReference.Resolve()
+                var interfaceMethods = from interfaceReference in typeDefinition.Interfaces
+                    let interfaceDefinition = interfaceReference.Resolve()
                     where interfaceDefinition != null
                     select interfaceDefinition.Methods;
 
@@ -787,7 +767,32 @@ namespace ApiApprover
             }
             return genericArguments.ToArray();
         }
+
+        private static readonly HashSet<string> SkipAttributeNames = new HashSet<string>
+        {
+            "System.CodeDom.Compiler.GeneratedCodeAttribute",
+            "System.ComponentModel.EditorBrowsableAttribute",
+            "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
+            "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+            "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
+            "System.Runtime.CompilerServices.ExtensionAttribute",
+            "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
+            "System.Reflection.DefaultMemberAttribute",
+            "System.Diagnostics.DebuggableAttribute",
+            "System.Diagnostics.DebuggerNonUserCodeAttribute",
+            "System.Diagnostics.DebuggerStepThroughAttribute",
+            "System.Reflection.AssemblyCompanyAttribute",
+            "System.Reflection.AssemblyConfigurationAttribute",
+            "System.Reflection.AssemblyCopyrightAttribute",
+            "System.Reflection.AssemblyDescriptionAttribute",
+            "System.Reflection.AssemblyFileVersionAttribute",
+            "System.Reflection.AssemblyInformationalVersionAttribute",
+            "System.Reflection.AssemblyProductAttribute",
+            "System.Reflection.AssemblyTitleAttribute",
+            "System.Reflection.AssemblyTrademarkAttribute"
+        };
     }
 }
+
 // ReSharper restore BitwiseOperatorOnEnumWihtoutFlags
 // ReSharper restore CheckNamespace

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Persisters\When_using_GlobalConnectionStringConfiguration.cs" />
     <Compile Include="Sagas\SecondaryIndexKeyBuilderTests.cs" />
     <Compile Include="Sagas\When_completing_saga.cs" />
+    <Compile Include="Sagas\When_executing_concurrently.cs" />
     <Compile Include="Sagas\When_updating_saga.cs" />
     <Compile Include="Sagas\When_saving_saga.cs" />
     <Compile Include="Sagas\When_getting_the_saga_entity.cs" />

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Sagas/When_executing_concurrently.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Sagas/When_executing_concurrently.cs
@@ -1,0 +1,170 @@
+﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Sagas
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Table;
+    using NServiceBus.Sagas;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// These tests try to mimic different concurrent scenarios using two persiters trying to access the same saga.
+    /// </summary>
+    public class When_executing_concurrently
+    {
+        public When_executing_concurrently()
+        {
+            connectionString = AzurePersistenceTests.GetConnectionString();
+            var account = CloudStorageAccount.Parse(connectionString);
+            var client = account.CreateCloudTableClient();
+            cloudTable = client.GetTableReference(typeof(ConcurrentSagaData).Name);
+        }
+
+        [SetUp]
+        public async Task SetUp()
+        {
+            await cloudTable.CreateIfNotExistsAsync().ConfigureAwait(false);
+            persister1 = new AzureSagaPersister(connectionString, true);
+            persister2 = new AzureSagaPersister(connectionString, true);
+
+            // clear whole table
+            var entities = await cloudTable.ExecuteQueryAsync(new TableQuery<TableEntity>()).ConfigureAwait(false);
+            foreach (var te in entities)
+            {
+                await cloudTable.DeleteIgnoringNotFound(te).ConfigureAwait(false);
+            }
+        }
+
+        [Test(Description = "Failed removal of the secondary index")]
+        public async Task Should_enable_inserting_when_only_secondary_exists()
+        {
+            const string v = "1";
+            await Save(persister1, v, Id1).ConfigureAwait(false);
+
+            // get by property just to load to cache
+            await GetByProperty(persister2).ConfigureAwait(false);
+
+            var entities = await cloudTable.ExecuteQueryAsync(new TableQuery<TableEntity>()).ConfigureAwait(false);
+            Guid guid;
+            var primary = entities.Single(te => Guid.TryParse(te.PartitionKey, out guid));
+            await cloudTable.DeleteIgnoringNotFound(primary);
+
+            // only secondary exists now, ensure it's null
+            var byProperty = await GetByProperty(persister2).ConfigureAwait(false);
+            Assert.IsNull(byProperty);
+
+            const string v2 = "2";
+
+            // save a new version
+            await Save(persister1, v2, Id2).ConfigureAwait(false);
+
+            byProperty = await GetByProperty(persister2).ConfigureAwait(false);
+            AssertSaga(byProperty, v2, Id2);
+        }
+
+        [Test]
+        public Task Should_enable_insert_saga_again_through_same_persister()
+        {
+            return Should_enable_insert_saga_again(persister1);
+        }
+
+        [Test]
+        public Task Should_enable_insert_saga_again_through_another_persister()
+        {
+            return Should_enable_insert_saga_again(persister2);
+        }
+
+        async Task Should_enable_insert_saga_again(ISagaPersister p)
+        {
+            const string v = "1";
+
+            await Save(persister1, v, Id1).ConfigureAwait(false);
+
+            var saga1 = await Get(persister1, Id1).ConfigureAwait(false);
+            var saga2 = await Get(persister2, Id1).ConfigureAwait(false);
+            var saga1ByProperty = await GetByProperty(persister1).ConfigureAwait(false);
+            var saga2ByProperty = await GetByProperty(persister2).ConfigureAwait(false);
+
+            AssertSaga(saga1, v, Id1);
+            AssertSaga(saga2, v, Id1);
+            AssertSaga(saga1ByProperty, v, Id1);
+            AssertSaga(saga2ByProperty, v, Id1);
+
+            await Complete(saga1, persister1).ConfigureAwait(false);
+
+            saga1 = await Get(persister1, Id1).ConfigureAwait(false);
+            saga2 = await Get(persister2, Id1).ConfigureAwait(false);
+            saga1ByProperty = await GetByProperty(persister1).ConfigureAwait(false);
+            saga2ByProperty = await GetByProperty(persister2).ConfigureAwait(false);
+
+            Assert.IsNull(saga1);
+            Assert.IsNull(saga2);
+            Assert.IsNull(saga1ByProperty);
+            Assert.IsNull(saga2ByProperty);
+
+            const string v2 = "2";
+            await Save(p, v2, Id2).ConfigureAwait(false);
+
+            saga1 = await Get(persister1, Id2).ConfigureAwait(false);
+            saga2 = await Get(persister2, Id2).ConfigureAwait(false);
+            saga1ByProperty = await GetByProperty(persister1).ConfigureAwait(false);
+            saga2ByProperty = await GetByProperty(persister2).ConfigureAwait(false);
+
+            AssertSaga(saga1, v2, Id2);
+            AssertSaga(saga2, v2, Id2);
+            AssertSaga(saga1ByProperty, v2, Id2);
+            AssertSaga(saga2ByProperty, v2, Id2);
+        }
+
+        static Task Complete(IContainSagaData saga, ISagaPersister persister)
+        {
+            return persister.Complete(saga, null, null);
+        }
+
+        static void AssertSaga(ConcurrentSagaData saga, string value, Guid id)
+        {
+            Assert.NotNull(saga);
+            Assert.AreEqual(id, saga.Id);
+            Assert.AreEqual(SagaCorrelationPropertyValue.Value, saga.CorrelationId);
+            Assert.AreEqual(value, saga.Value);
+        }
+
+        static Task<ConcurrentSagaData> Get(ISagaPersister persister, Guid id)
+        {
+            return persister.Get<ConcurrentSagaData>(id, null, null);
+        }
+
+        static Task<ConcurrentSagaData> GetByProperty(ISagaPersister persister)
+        {
+            return persister.Get<ConcurrentSagaData>(SagaCorrelationPropertyValue.Name, SagaCorrelationPropertyValue.Value, null, null);
+        }
+
+        static Task Save(ISagaPersister persister, string value, Guid id)
+        {
+            return persister.Save(new ConcurrentSagaData
+            {
+                Id = id,
+                CorrelationId = CorrelationIdValue,
+                Value = value
+            }, SagaCorrelationPropertyValue, null, null);
+        }
+
+        readonly CloudTable cloudTable;
+        readonly string connectionString;
+
+        AzureSagaPersister persister1;
+        AzureSagaPersister persister2;
+        const string CorrelationIdValue = "DB0F4000-5B9C-4ADE-9AB0-04305A5CABBD";
+
+        static readonly Guid Id1 = new Guid("7FCF55F6-4AEB-40C7-86B9-2AB535664381");
+        static readonly Guid Id2 = new Guid("7FCF55F6-4AEB-40C7-86B9-2AB535664381");
+        static readonly SagaCorrelationProperty SagaCorrelationPropertyValue = new SagaCorrelationProperty("CorrelationId", CorrelationIdValue);
+
+        class ConcurrentSagaData : ContainSagaData
+        {
+            public string CorrelationId { get; set; }
+            public string Value { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
@@ -113,6 +113,7 @@
     <Compile Include="SagaPersisters\AzureStorageSagaGuard.cs" />
     <Compile Include="SagaPersisters\AzureStorageSagaDefaults.cs" />
     <Compile Include="SagaPersisters\AzureStorageSagaPersistence.cs" />
+    <Compile Include="SagaPersisters\DictionaryTableEntityExtensions.cs" />
     <Compile Include="SagaPersisters\DuplicatedSagaFoundException.cs" />
     <Compile Include="SagaPersisters\RetryNeededException.cs" />
     <Compile Include="SagaPersisters\SecondaryIndices\SecondaryIndexKeyBuilder.cs" />

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
@@ -54,9 +54,9 @@
             {
                 etags.Add(entity, tableEntity.ETag);
                 EntityProperty value;
-                if (tableEntity.TryGetValue(SecondaryIndexEntry, out value))
+                if (tableEntity.TryGetValue(SecondaryIndexIndicatorProperty, out value))
                 {
-                    secondaryIndexKeys.Add(entity, PartitionRowKeyTuple.Parse(value.StringValue));
+                    secondaryIndexLocalCache.Add(entity, PartitionRowKeyTuple.Parse(value.StringValue));
                 }
             }
 
@@ -124,7 +124,7 @@
         Task RemoveSecondaryIndex(IContainSagaData sagaData)
         {
             PartitionRowKeyTuple secondaryIndexKey;
-            if (secondaryIndexKeys.TryGetValue(sagaData, out secondaryIndexKey))
+            if (secondaryIndexLocalCache.TryGetValue(sagaData, out secondaryIndexKey))
             {
                 return secondaryIndices.RemoveSecondary(sagaData.GetType(), secondaryIndexKey);
             }
@@ -211,7 +211,7 @@
 
             if (secondaryIndexKey == null && update)
             {
-                secondaryIndexKeys.TryGetValue(entity, out secondaryIndexKey);
+                secondaryIndexLocalCache.TryGetValue(entity, out secondaryIndexKey);
             }
 
             var properties = SelectPropertiesToPersist(type);
@@ -225,7 +225,7 @@
 
             if (secondaryIndexKey != null)
             {
-                toPersist.Add(SecondaryIndexEntry, secondaryIndexKey.ToString());
+                toPersist.Add(SecondaryIndexIndicatorProperty, secondaryIndexKey.ToString());
             }
 
             //no longer using InsertOrReplace as it ignores concurrency checks
@@ -242,9 +242,9 @@
         bool autoUpdateSchema;
         CloudTableClient client;
         SecondaryIndexPersister secondaryIndices;
-        const string SecondaryIndexEntry = "NServiceBus_2ndIndexKey";
+        const string SecondaryIndexIndicatorProperty = "NServiceBus_2ndIndexKey";
         static ConcurrentDictionary<string, bool> tableCreated = new ConcurrentDictionary<string, bool>();
         static ConditionalWeakTable<object, string> etags = new ConditionalWeakTable<object, string>();
-        static ConditionalWeakTable<object, PartitionRowKeyTuple> secondaryIndexKeys = new ConditionalWeakTable<object, PartitionRowKeyTuple>();
+        static ConditionalWeakTable<object, PartitionRowKeyTuple> secondaryIndexLocalCache = new ConditionalWeakTable<object, PartitionRowKeyTuple>();
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
@@ -85,7 +85,8 @@
             var tableName = sagaData.GetType().Name;
             var table = client.GetTableReference(tableName);
 
-            var query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, sagaData.Id.ToString()));
+            var sagaId = sagaData.Id;
+            var query = GenerateSagaTableQuery<DictionaryTableEntity>(sagaId);
 
             var entity = (await table.ExecuteQueryAsync(query).ConfigureAwait(false)).SafeFirstOrDefault();
             if (entity == null)
@@ -100,8 +101,13 @@
             }
             catch
             {
-                log.Warn($"Removal of the secondary index entry for the following saga failed: '{sagaData.Id}'");
+                log.Warn($"Removal of the secondary index entry for the following saga failed: '{sagaId}'");
             }
+        }
+
+        public static TableQuery<TEntity> GenerateSagaTableQuery<TEntity>(Guid sagaId)
+        {
+            return new TableQuery<TEntity>().Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, sagaId.ToString()));
         }
 
         Task RemoveSecondaryIndex(IContainSagaData sagaData)

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
@@ -8,21 +8,15 @@
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
+    using Extensibility;
+    using Logging;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Table;
-    using Extensibility;
-    using Persistence;
-    using SecondaryIndices;
     using Sagas;
+    using SecondaryIndices;
 
     class AzureSagaPersister : ISagaPersister
     {
-        static ConcurrentDictionary<string, bool> tableCreated = new ConcurrentDictionary<string, bool>();
-        static ConditionalWeakTable<object, string> etags = new ConditionalWeakTable<object, string>();
-        bool autoUpdateSchema;
-        CloudTableClient client;
-        SecondaryIndexPersister secondaryIndices;
-
         public AzureSagaPersister(string connectionString, bool autoUpdateSchema)
         {
             this.autoUpdateSchema = autoUpdateSchema;
@@ -34,14 +28,19 @@
 
         public async Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context)
         {
-            // These operations must be executed sequentially
-            await secondaryIndices.Insert(sagaData, correlationProperty).ConfigureAwait(false);
-            await Persist(sagaData).ConfigureAwait(false);
+            // The following operations have to be executed sequentially:
+            // 1) insert the 2nd index, containing the primary saga data (just in case of a failure)
+            // 2) insert the primary saga data in its row, storing the identifier of the secondary index as well (for completions)
+            // 3) remove the data of the primary from the 2nd index. It will be no longer needed
+
+            var secondaryIndexKey = await secondaryIndices.Insert(sagaData, correlationProperty).ConfigureAwait(false);
+            await Persist(sagaData, secondaryIndexKey).ConfigureAwait(false);
+            await secondaryIndices.MarkAsHavingPrimaryPersisted(sagaData, correlationProperty).ConfigureAwait(false);
         }
 
         public Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context)
         {
-            return Persist(sagaData);
+            return Persist(sagaData, null);
         }
 
         public async Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context) where TSagaData : IContainSagaData
@@ -49,11 +48,16 @@
             var id = sagaId.ToString();
             var entityType = typeof(TSagaData);
             var tableEntity = await GetDictionaryTableEntity(id, entityType).ConfigureAwait(false);
-            var entity = (TSagaData) ToEntity(entityType, tableEntity);
+            var entity = DictionaryTableEntityExtensions.ToEntity<TSagaData>(tableEntity);
 
             if (!Equals(entity, default(TSagaData)))
             {
                 etags.Add(entity, tableEntity.ETag);
+                EntityProperty value;
+                if (tableEntity.TryGetValue(SecondaryIndexEntry, out value))
+                {
+                    secondaryIndexKeys.Add(entity, PartitionRowKeyTuple.Parse(value.StringValue));
+                }
             }
 
             return entity;
@@ -67,7 +71,13 @@
                 return default(TSagaData);
             }
 
-            return await Get<TSagaData>(id.Value, session, context).ConfigureAwait(false);
+            var sagaData = await Get<TSagaData>(id.Value, session, context).ConfigureAwait(false);
+            if (Equals(sagaData, default(TSagaData)))
+            {
+                secondaryIndices.InvalidateCacheIfAny(propertyName, propertyValue, typeof(TSagaData));
+            }
+
+            return sagaData;
         }
 
         public async Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context)
@@ -83,24 +93,26 @@
                 return; // should not try to delete saga data that does not exist, this situation can occur on retry or parallel execution
             }
 
+            await table.DeleteIgnoringNotFound(entity).ConfigureAwait(false);
             try
             {
-                await table.ExecuteAsync(TableOperation.Delete(entity)).ConfigureAwait(false);
+                await RemoveSecondaryIndex(sagaData).ConfigureAwait(false);
             }
-            catch (StorageException ex)
+            catch
             {
-                // Horrible logic to check if item has already been deleted or not
-                var webException = ex.InnerException as WebException;
-                if (webException?.Response != null)
-                {
-                    var response = (HttpWebResponse) webException.Response;
-                    if ((int) response.StatusCode != 404)
-                    {
-                        // Was not a previously deleted exception, throw again
-                        throw;
-                    }
-                }
+                log.Warn($"Removal of the secondary index entry for the following saga failed: '{sagaData.Id}'");
             }
+        }
+
+        Task RemoveSecondaryIndex(IContainSagaData sagaData)
+        {
+            PartitionRowKeyTuple secondaryIndexKey;
+            if (secondaryIndexKeys.TryGetValue(sagaData, out secondaryIndexKey))
+            {
+                return secondaryIndices.RemoveSecondary(sagaData.GetType(), secondaryIndexKey);
+            }
+
+            return TaskEx.CompletedTask;
         }
 
         async Task<DictionaryTableEntity> GetDictionaryTableEntity(string sagaId, Type entityType)
@@ -126,71 +138,7 @@
             }
         }
 
-        async Task<DictionaryTableEntity> GetDictionaryTableEntity(Type type, string property, object value)
-        {
-            var tableName = type.Name;
-            var table = client.GetTableReference(tableName);
-
-            var query = BuildWherePropertyQuery(type, property, value);
-            if (query == null)
-            {
-                return null;
-            }
-
-            var tableEntity = (await table.ExecuteQueryAsync(query).ConfigureAwait(false)).SafeFirstOrDefault();
-            return tableEntity;
-        }
-
-        static TableQuery<DictionaryTableEntity> BuildWherePropertyQuery(Type type, string property, object value)
-        {
-            TableQuery<DictionaryTableEntity> query;
-
-            var propertyInfo = type.GetProperty(property);
-            if (propertyInfo == null)
-            {
-                return null;
-            }
-
-            if (propertyInfo.PropertyType == typeof(byte[]))
-            {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBinary(property, QueryComparisons.Equal, (byte[]) value));
-            }
-            else if (propertyInfo.PropertyType == typeof(bool))
-            {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBool(property, QueryComparisons.Equal, (bool) value));
-            }
-            else if (propertyInfo.PropertyType == typeof(DateTime))
-            {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDate(property, QueryComparisons.Equal, (DateTime) value));
-            }
-            else if (propertyInfo.PropertyType == typeof(Guid))
-            {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForGuid(property, QueryComparisons.Equal, (Guid) value));
-            }
-            else if (propertyInfo.PropertyType == typeof(Int32))
-            {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForInt(property, QueryComparisons.Equal, (int) value));
-            }
-            else if (propertyInfo.PropertyType == typeof(Int64))
-            {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForLong(property, QueryComparisons.Equal, (long) value));
-            }
-            else if (propertyInfo.PropertyType == typeof(Double))
-            {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDouble(property, QueryComparisons.Equal, (double) value));
-            }
-            else if (propertyInfo.PropertyType == typeof(string))
-            {
-                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterCondition(property, QueryComparisons.Equal, (string) value));
-            }
-            else
-            {
-                throw new NotSupportedException($"The property type '{propertyInfo.PropertyType.Name}' is not supported in windows azure table storage");
-            }
-            return query;
-        }
-
-        async Task Persist(IContainSagaData saga)
+        async Task Persist(IContainSagaData saga, PartitionRowKeyTuple secondaryIndexKey)
         {
             var type = saga.GetType();
             var table = await GetTable(type).ConfigureAwait(false);
@@ -199,7 +147,7 @@
 
             var batch = new TableBatchOperation();
 
-            AddObjectToBatch(batch, saga, partitionKey);
+            AddObjectToBatch(batch, saga, partitionKey, secondaryIndexKey);
 
             await table.ExecuteBatchAsync(batch).ConfigureAwait(false);
         }
@@ -218,7 +166,7 @@
 
         async Task<Guid[]> ScanForSaga(Type sagaType, string propertyName, object propertyValue)
         {
-            var query = BuildWherePropertyQuery(sagaType, propertyName, propertyValue);
+            var query = DictionaryTableEntityExtensions.BuildWherePropertyQuery(sagaType, propertyName, propertyValue);
             query.SelectColumns = new List<string>
             {
                 "PartitionKey",
@@ -231,7 +179,7 @@
             return entities.Select(entity => Guid.ParseExact(entity.PartitionKey, "D")).ToArray();
         }
 
-        void AddObjectToBatch(TableBatchOperation batch, object entity, string partitionKey, string rowkey = "")
+        static void AddObjectToBatch(TableBatchOperation batch, object entity, string partitionKey, PartitionRowKeyTuple secondaryIndexKey, string rowkey = "")
         {
             if (rowkey == "")
             {
@@ -241,16 +189,27 @@
 
             var type = entity.GetType();
             string etag;
+
             var update = etags.TryGetValue(entity, out etag);
+
+            if (secondaryIndexKey == null && update)
+            {
+                secondaryIndexKeys.TryGetValue(entity, out secondaryIndexKey);
+            }
 
             var properties = SelectPropertiesToPersist(type);
 
-            var toPersist = ToDictionaryTableEntity(entity, new DictionaryTableEntity
+            var toPersist = DictionaryTableEntityExtensions.ToDictionaryTableEntity(entity, new DictionaryTableEntity
             {
                 PartitionKey = partitionKey,
                 RowKey = rowkey,
                 ETag = etag
             }, properties);
+
+            if (secondaryIndexKey != null)
+            {
+                toPersist.Add(SecondaryIndexEntry, secondaryIndexKey.ToString());
+            }
 
             //no longer using InsertOrReplace as it ignores concurrency checks
             batch.Add(update ? TableOperation.Replace(toPersist) : TableOperation.Insert(toPersist));
@@ -261,107 +220,14 @@
             return sagaType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         }
 
-        DictionaryTableEntity ToDictionaryTableEntity(object entity, DictionaryTableEntity toPersist, IEnumerable<PropertyInfo> properties)
-        {
-            foreach (var propertyInfo in properties)
-            {
-                if (propertyInfo.PropertyType == typeof(byte[]))
-                {
-                    toPersist[propertyInfo.Name] = new EntityProperty((byte[]) propertyInfo.GetValue(entity, null));
-                }
-                else if (propertyInfo.PropertyType == typeof(bool))
-                {
-                    toPersist[propertyInfo.Name] = new EntityProperty((bool) propertyInfo.GetValue(entity, null));
-                }
-                else if (propertyInfo.PropertyType == typeof(DateTime))
-                {
-                    toPersist[propertyInfo.Name] = new EntityProperty((DateTime) propertyInfo.GetValue(entity, null));
-                }
-                else if (propertyInfo.PropertyType == typeof(Guid))
-                {
-                    toPersist[propertyInfo.Name] = new EntityProperty((Guid) propertyInfo.GetValue(entity, null));
-                }
-                else if (propertyInfo.PropertyType == typeof(Int32))
-                {
-                    toPersist[propertyInfo.Name] = new EntityProperty((Int32) propertyInfo.GetValue(entity, null));
-                }
-                else if (propertyInfo.PropertyType == typeof(Int64))
-                {
-                    toPersist[propertyInfo.Name] = new EntityProperty((Int64) propertyInfo.GetValue(entity, null));
-                }
-                else if (propertyInfo.PropertyType == typeof(Double))
-                {
-                    toPersist[propertyInfo.Name] = new EntityProperty((Double) propertyInfo.GetValue(entity, null));
-                }
-                else if (propertyInfo.PropertyType == typeof(string))
-                {
-                    toPersist[propertyInfo.Name] = new EntityProperty((string) propertyInfo.GetValue(entity, null));
-                }
-                else
-                {
-                    throw new NotSupportedException($"The property type '{propertyInfo.PropertyType.Name}' is not supported in windows azure table storage");
-                }
-            }
-            return toPersist;
-        }
+        readonly ILog log = LogManager.GetLogger<AzureSagaPersister>();
 
-        object ToEntity(Type entityType, DictionaryTableEntity entity)
-        {
-            if (entity == null)
-            {
-                return null;
-            }
-
-            var toCreate = Activator.CreateInstance(entityType);
-            foreach (var propertyInfo in entityType.GetProperties())
-            {
-                if (entity.ContainsKey(propertyInfo.Name))
-                {
-                    if (propertyInfo.PropertyType == typeof(byte[]))
-                    {
-                        propertyInfo.SetValue(toCreate, entity[propertyInfo.Name].BinaryValue, null);
-                    }
-                    else if (propertyInfo.PropertyType == typeof(bool))
-                    {
-                        var boolean = entity[propertyInfo.Name].BooleanValue;
-                        propertyInfo.SetValue(toCreate, boolean.HasValue && boolean.Value, null);
-                    }
-                    else if (propertyInfo.PropertyType == typeof(DateTime))
-                    {
-                        var dateTimeOffset = entity[propertyInfo.Name].DateTimeOffsetValue;
-                        propertyInfo.SetValue(toCreate, dateTimeOffset.HasValue ? dateTimeOffset.Value.DateTime : default(DateTime), null);
-                    }
-                    else if (propertyInfo.PropertyType == typeof(Guid))
-                    {
-                        var guid = entity[propertyInfo.Name].GuidValue;
-                        propertyInfo.SetValue(toCreate, guid.HasValue ? guid.Value : default(Guid), null);
-                    }
-                    else if (propertyInfo.PropertyType == typeof(Int32))
-                    {
-                        var int32 = entity[propertyInfo.Name].Int32Value;
-                        propertyInfo.SetValue(toCreate, int32.HasValue ? int32.Value : default(Int32), null);
-                    }
-                    else if (propertyInfo.PropertyType == typeof(Double))
-                    {
-                        var d = entity[propertyInfo.Name].DoubleValue;
-                        propertyInfo.SetValue(toCreate, d.HasValue ? d.Value : default(Int64), null);
-                    }
-                    else if (propertyInfo.PropertyType == typeof(Int64))
-                    {
-                        var int64 = entity[propertyInfo.Name].Int64Value;
-                        propertyInfo.SetValue(toCreate, int64.HasValue ? int64.Value : default(Int64), null);
-                    }
-                    else if (propertyInfo.PropertyType == typeof(string))
-                    {
-                        propertyInfo.SetValue(toCreate, entity[propertyInfo.Name].StringValue, null);
-                    }
-                    else
-                    {
-                        throw new NotSupportedException($"The property type '{propertyInfo.PropertyType.Name}' is not supported in windows azure table storage");
-                    }
-                }
-            }
-            return toCreate;
-        }
+        bool autoUpdateSchema;
+        CloudTableClient client;
+        SecondaryIndexPersister secondaryIndices;
+        const string SecondaryIndexEntry = "NServiceBus_2ndIndexKey";
+        static ConcurrentDictionary<string, bool> tableCreated = new ConcurrentDictionary<string, bool>();
+        static ConditionalWeakTable<object, string> etags = new ConditionalWeakTable<object, string>();
+        static ConditionalWeakTable<object, PartitionRowKeyTuple> secondaryIndexKeys = new ConditionalWeakTable<object, PartitionRowKeyTuple>();
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntity.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntity.cs
@@ -8,71 +8,14 @@
 
     class DictionaryTableEntity : TableEntity, IDictionary<string, EntityProperty>
     {
-        IDictionary<string, EntityProperty> properties;
-
         public DictionaryTableEntity()
         {
             properties = new Dictionary<string, EntityProperty>();
         }
 
-        public override void ReadEntity(IDictionary<string, EntityProperty> entityProperties, OperationContext operationContext)
-        {
-            properties = entityProperties;
-        }
-
-        public override IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext)
-        {
-            return properties;
-        }
-
         public void Add(string key, EntityProperty value)
         {
             properties.Add(key, value);
-        }
-
-        public void Add(string key, bool value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, byte[] value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, DateTime? value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, DateTimeOffset? value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, double value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, Guid value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, int value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, long value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, string value)
-        {
-            properties.Add(key, new EntityProperty(value));
         }
 
         public bool ContainsKey(string key)
@@ -138,5 +81,62 @@
         {
             return properties.GetEnumerator();
         }
+
+        public override void ReadEntity(IDictionary<string, EntityProperty> entityProperties, OperationContext operationContext)
+        {
+            properties = entityProperties;
+        }
+
+        public override IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext)
+        {
+            return properties;
+        }
+
+        public void Add(string key, bool value)
+        {
+            properties.Add(key, new EntityProperty(value));
+        }
+
+        public void Add(string key, byte[] value)
+        {
+            properties.Add(key, new EntityProperty(value));
+        }
+
+        public void Add(string key, DateTime? value)
+        {
+            properties.Add(key, new EntityProperty(value));
+        }
+
+        public void Add(string key, DateTimeOffset? value)
+        {
+            properties.Add(key, new EntityProperty(value));
+        }
+
+        public void Add(string key, double value)
+        {
+            properties.Add(key, new EntityProperty(value));
+        }
+
+        public void Add(string key, Guid value)
+        {
+            properties.Add(key, new EntityProperty(value));
+        }
+
+        public void Add(string key, int value)
+        {
+            properties.Add(key, new EntityProperty(value));
+        }
+
+        public void Add(string key, long value)
+        {
+            properties.Add(key, new EntityProperty(value));
+        }
+
+        public void Add(string key, string value)
+        {
+            properties.Add(key, new EntityProperty(value));
+        }
+
+        IDictionary<string, EntityProperty> properties;
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntityExtensions.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntityExtensions.cs
@@ -1,0 +1,168 @@
+namespace NServiceBus.Persistence.AzureStorage
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using Microsoft.WindowsAzure.Storage.Table;
+
+    static class DictionaryTableEntityExtensions
+    {
+        public static TEntity ToEntity<TEntity>(DictionaryTableEntity entity)
+        {
+            return (TEntity) ToEntity(typeof(TEntity), entity);
+        }
+
+        public static object ToEntity(Type entityType, DictionaryTableEntity entity)
+        {
+            if (entity == null)
+            {
+                return null;
+            }
+
+            var toCreate = Activator.CreateInstance(entityType);
+            foreach (var propertyInfo in entityType.GetProperties())
+            {
+                if (entity.ContainsKey(propertyInfo.Name))
+                {
+                    if (propertyInfo.PropertyType == typeof(byte[]))
+                    {
+                        propertyInfo.SetValue(toCreate, entity[propertyInfo.Name].BinaryValue, null);
+                    }
+                    else if (propertyInfo.PropertyType == typeof(bool))
+                    {
+                        var boolean = entity[propertyInfo.Name].BooleanValue;
+                        propertyInfo.SetValue(toCreate, boolean.HasValue && boolean.Value, null);
+                    }
+                    else if (propertyInfo.PropertyType == typeof(DateTime))
+                    {
+                        var dateTimeOffset = entity[propertyInfo.Name].DateTimeOffsetValue;
+                        propertyInfo.SetValue(toCreate, dateTimeOffset?.DateTime ?? default(DateTime), null);
+                    }
+                    else if (propertyInfo.PropertyType == typeof(Guid))
+                    {
+                        var guid = entity[propertyInfo.Name].GuidValue;
+                        propertyInfo.SetValue(toCreate, guid ?? default(Guid), null);
+                    }
+                    else if (propertyInfo.PropertyType == typeof(int))
+                    {
+                        var int32 = entity[propertyInfo.Name].Int32Value;
+                        propertyInfo.SetValue(toCreate, int32 ?? default(int), null);
+                    }
+                    else if (propertyInfo.PropertyType == typeof(double))
+                    {
+                        var d = entity[propertyInfo.Name].DoubleValue;
+                        propertyInfo.SetValue(toCreate, d ?? default(long), null);
+                    }
+                    else if (propertyInfo.PropertyType == typeof(long))
+                    {
+                        var int64 = entity[propertyInfo.Name].Int64Value;
+                        propertyInfo.SetValue(toCreate, int64 ?? default(long), null);
+                    }
+                    else if (propertyInfo.PropertyType == typeof(string))
+                    {
+                        propertyInfo.SetValue(toCreate, entity[propertyInfo.Name].StringValue, null);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"The property type '{propertyInfo.PropertyType.Name}' is not supported in windows azure table storage");
+                    }
+                }
+            }
+            return toCreate;
+        }
+
+        public static DictionaryTableEntity ToDictionaryTableEntity(object entity, DictionaryTableEntity toPersist, IEnumerable<PropertyInfo> properties)
+        {
+            foreach (var propertyInfo in properties)
+            {
+                if (propertyInfo.PropertyType == typeof(byte[]))
+                {
+                    toPersist[propertyInfo.Name] = new EntityProperty((byte[]) propertyInfo.GetValue(entity, null));
+                }
+                else if (propertyInfo.PropertyType == typeof(bool))
+                {
+                    toPersist[propertyInfo.Name] = new EntityProperty((bool) propertyInfo.GetValue(entity, null));
+                }
+                else if (propertyInfo.PropertyType == typeof(DateTime))
+                {
+                    toPersist[propertyInfo.Name] = new EntityProperty((DateTime) propertyInfo.GetValue(entity, null));
+                }
+                else if (propertyInfo.PropertyType == typeof(Guid))
+                {
+                    toPersist[propertyInfo.Name] = new EntityProperty((Guid) propertyInfo.GetValue(entity, null));
+                }
+                else if (propertyInfo.PropertyType == typeof(int))
+                {
+                    toPersist[propertyInfo.Name] = new EntityProperty((int) propertyInfo.GetValue(entity, null));
+                }
+                else if (propertyInfo.PropertyType == typeof(long))
+                {
+                    toPersist[propertyInfo.Name] = new EntityProperty((long) propertyInfo.GetValue(entity, null));
+                }
+                else if (propertyInfo.PropertyType == typeof(double))
+                {
+                    toPersist[propertyInfo.Name] = new EntityProperty((double) propertyInfo.GetValue(entity, null));
+                }
+                else if (propertyInfo.PropertyType == typeof(string))
+                {
+                    toPersist[propertyInfo.Name] = new EntityProperty((string) propertyInfo.GetValue(entity, null));
+                }
+                else
+                {
+                    throw new NotSupportedException($"The property type '{propertyInfo.PropertyType.Name}' is not supported in windows azure table storage");
+                }
+            }
+            return toPersist;
+        }
+
+        public static TableQuery<DictionaryTableEntity> BuildWherePropertyQuery(Type type, string property, object value)
+        {
+            TableQuery<DictionaryTableEntity> query;
+
+            var propertyInfo = type.GetProperty(property);
+            if (propertyInfo == null)
+            {
+                return null;
+            }
+
+            if (propertyInfo.PropertyType == typeof(byte[]))
+            {
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBinary(property, QueryComparisons.Equal, (byte[]) value));
+            }
+            else if (propertyInfo.PropertyType == typeof(bool))
+            {
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForBool(property, QueryComparisons.Equal, (bool) value));
+            }
+            else if (propertyInfo.PropertyType == typeof(DateTime))
+            {
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDate(property, QueryComparisons.Equal, (DateTime) value));
+            }
+            else if (propertyInfo.PropertyType == typeof(Guid))
+            {
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForGuid(property, QueryComparisons.Equal, (Guid) value));
+            }
+            else if (propertyInfo.PropertyType == typeof(int))
+            {
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForInt(property, QueryComparisons.Equal, (int) value));
+            }
+            else if (propertyInfo.PropertyType == typeof(long))
+            {
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForLong(property, QueryComparisons.Equal, (long) value));
+            }
+            else if (propertyInfo.PropertyType == typeof(double))
+            {
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterConditionForDouble(property, QueryComparisons.Equal, (double) value));
+            }
+            else if (propertyInfo.PropertyType == typeof(string))
+            {
+                query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterCondition(property, QueryComparisons.Equal, (string) value));
+            }
+            else
+            {
+                throw new NotSupportedException($"The property type '{propertyInfo.PropertyType.Name}' is not supported in windows azure table storage");
+            }
+
+            return query;
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/PartitionRowKeyTuple.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/PartitionRowKeyTuple.cs
@@ -1,17 +1,18 @@
 ﻿namespace NServiceBus.Persistence.AzureStorage.SecondaryIndices
 {
+    using System;
     using Microsoft.WindowsAzure.Storage.Table;
 
     sealed class PartitionRowKeyTuple
     {
-        public string PartitionKey { get; }
-        public string RowKey { get; }
-
         public PartitionRowKeyTuple(string partitionKey, string rowKey)
         {
             PartitionKey = partitionKey;
             RowKey = rowKey;
         }
+
+        public string PartitionKey { get; }
+        public string RowKey { get; }
 
         public void Apply(ITableEntity entity)
         {
@@ -48,5 +49,27 @@
                 return ((PartitionKey?.GetHashCode() ?? 0)*397) ^ (RowKey?.GetHashCode() ?? 0);
             }
         }
+
+        public override string ToString()
+        {
+            return PartitionKey + Separator + RowKey;
+        }
+
+        public static PartitionRowKeyTuple Parse(string str)
+        {
+            if (string.IsNullOrWhiteSpace(str))
+            {
+                return null;
+            }
+            var strings = str.Split(Separators, StringSplitOptions.None);
+            return new PartitionRowKeyTuple(strings[0], strings[1]);
+        }
+
+        const string Separator = "#";
+
+        static readonly string[] Separators =
+        {
+            Separator
+        };
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/PartitionRowKeyTuple.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/PartitionRowKeyTuple.cs
@@ -61,15 +61,10 @@
             {
                 return null;
             }
-            var strings = str.Split(Separators, StringSplitOptions.None);
+            var strings = str.Split(new [] { Separator }, StringSplitOptions.None);
             return new PartitionRowKeyTuple(strings[0], strings[1]);
         }
 
         const string Separator = "#";
-
-        static readonly string[] Separators =
-        {
-            Separator
-        };
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexPersister.cs
@@ -98,8 +98,8 @@
 
                         try
                         {
-                            await table.ExecuteAsync(TableOperation.Delete(existingSecondaryIndexEntity)).ConfigureAwait(false);
-                            await table.ExecuteAsync(TableOperation.Insert(newSecondaryIndexEntity)).ConfigureAwait(false);
+                            //this single call replaces a pair of calls that did a Delete followed by an Insert
+                            await table.ExecuteAsync(TableOperation.InsertOrReplace(newSecondaryIndexEntity)).ConfigureAwait(false);
                             return key;
                         }
                         catch (Exception exception)

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexPersister.cs
@@ -198,9 +198,9 @@
 
             var sagaType = sagaData.GetType();
             var table = await getTableForSaga(sagaType).ConfigureAwait(false);
-            var key = SecondaryIndexKeyBuilder.BuildTableKey(sagaType, correlationProperty);
+            var secondaryIndexKey = SecondaryIndexKeyBuilder.BuildTableKey(sagaType, correlationProperty);
 
-            var secondaryIndexTableEntity = CreateIndexingOnlyEntity(key, sagaData.Id);
+            var secondaryIndexTableEntity = CreateIndexingOnlyEntity(secondaryIndexKey, sagaData.Id);
             secondaryIndexTableEntity.ETag = "*";
 
             await table.ExecuteAsync(TableOperation.Replace(secondaryIndexTableEntity)).ConfigureAwait(false);

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexPersister.cs
@@ -99,6 +99,7 @@
                         try
                         {
                             //this single call replaces a pair of calls that did a Delete followed by an Insert
+                            newSecondaryIndexEntity.ETag = existingSecondaryIndexEntity?.ETag ?? "*";
                             await table.ExecuteAsync(TableOperation.InsertOrReplace(newSecondaryIndexEntity)).ConfigureAwait(false);
                             return key;
                         }


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.Persistence.AzureStorage/issues/74

The approach to solve is following:
- store the identifier of the created secondary index in the primary under a key (just add it to the `DictionaryTableEntity` as an artificial property
- when loaded, store it as `ETag` in a `ConditionalWeakTable`
- when saga completed try to remove the secondary (on failure, we won't retry. There may be an orphan if sth goes wrong).

This approach has been taken as the one that will satisfy the condition of removal under usual circumstances, possibly leaving some orphans when completion is done, but the following removal of the secondary fail.

This SO question brings some background to it why removal of the secondary is needed.
http://stackoverflow.com/questions/37341926/secondaryindexpersister-on-azure-is-throwing-exception-when-saga-is-started-with
