### PR TITLE
Subscriptions should ingore message versions

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Subscriptions/When_subscribing.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Subscriptions/When_subscribing.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Threading.Tasks;
+    using Extensibility;
     using Unicast.Subscriptions;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
     using NUnit.Framework;
@@ -67,9 +68,33 @@
             Assert.That(subscription.TransportAddress, Is.EqualTo("address://test-queue"));
             Assert.That(subscription.Endpoint, Is.EqualTo("endpointName"));
         }
+
+        [Test]
+        public async Task ensure_that_the_subscription_selects_proper_message_types()
+        {
+            var persister = SubscriptionTestHelper.CreateAzureSubscriptionStorage();
+
+            await persister.Subscribe(new Subscriber("address://test-queue", "endpointName"), new MessageType(typeof(TestMessage)), new ContextBag()).ConfigureAwait(false);
+            await persister.Subscribe(new Subscriber("address://test-queue2", "endpointName"), new MessageType(typeof(TestMessagea)), new ContextBag()).ConfigureAwait(false);
+
+            var subscribers = await persister.GetSubscriberAddressesForMessage(new[]
+            {
+                new MessageType(typeof(TestMessage))
+            }, new ContextBag()).ConfigureAwait(false);
+
+            Assert.That(subscribers.Count(), Is.EqualTo(1));
+
+            var subscription = subscribers.ToArray()[0];
+            Assert.That(subscription.TransportAddress, Is.EqualTo("address://test-queue"));
+            Assert.That(subscription.Endpoint, Is.EqualTo("endpointName"));
+        }
     }
 
     class TestMessage
+    {
+    }
+
+    class TestMessagea
     {
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Subscriptions/When_subscribing.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Subscriptions/When_subscribing.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Subscriptions
 {
+    using System;
     using System.Linq;
     using System.Threading.Tasks;
     using Unicast.Subscriptions;
@@ -29,6 +30,36 @@
             await persister.Subscribe(new Subscriber("address://test-queue", "endpointName"), messageType, null);
 
             var subscribers = await persister.GetSubscriberAddressesForMessage(messageTypes, null);
+
+            Assert.That(subscribers.Count(), Is.EqualTo(1));
+
+            var subscription = subscribers.ToArray()[0];
+            Assert.That(subscription.TransportAddress, Is.EqualTo("address://test-queue"));
+            Assert.That(subscription.Endpoint, Is.EqualTo("endpointName"));
+        }
+
+        [Test]
+        public async Task ensure_that_the_subscription_is_version_ignorant()
+        {
+            var persister = SubscriptionTestHelper.CreateAzureSubscriptionStorage();
+
+            var name = typeof(TestMessage).FullName;
+
+            var messageTypes = new[]
+            {
+                new MessageType(name, new Version(1,2,3)),
+                new MessageType(name, new Version(4,2,3)),
+            };
+
+            foreach (var messageType in messageTypes)
+            {
+                await persister.Subscribe(new Subscriber("address://test-queue", "endpointName"), messageType, null);
+            }
+
+            var subscribers = await persister.GetSubscriberAddressesForMessage(new[]
+            {
+                new MessageType(typeof(TestMessage))
+            }, null);
 
             Assert.That(subscribers.Count(), Is.EqualTo(1));
 

--- a/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureSubscriptionStorage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureSubscriptionStorage.cs
@@ -101,20 +101,43 @@
         /// <returns>Subscription addresses that were found for the provided messageTypes</returns>
         public async Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context)
         {
-            var subscribers = new List<Subscriber>();
+            var subscribers = new HashSet<Subscriber>(SubscriberComparer.Instance);
             var table = client.GetTableReference(subscriptionTableName);
 
             foreach (var messageType in messageTypes)
             {
-                var query = new TableQuery<Subscription>().Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, messageType.ToString()));
+                var name = messageType.TypeName;
+                var lastNameChar = name[name.Length - 1];
+                var nextChar = (char)(lastNameChar + 1);
+                var lowerBound = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, name);
+                var upperBound = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, name.Substring(0, name.Length - 1) + nextChar);
+                var query = new TableQuery<Subscription>().Where(TableQuery.CombineFilters(lowerBound, "and", upperBound));
 
                 var subscriptions = await table.ExecuteQueryAsync(query).ConfigureAwait(false);
                 var results = subscriptions.Select(s => new Subscriber(DecodeFrom64(s.RowKey), s.EndpointName));
 
-                subscribers.AddRange(results);
+                foreach (var subscriber in results)
+                {
+                    subscribers.Add(subscriber);
+                }
             }
 
             return subscribers;
+        }
+
+        class SubscriberComparer : IEqualityComparer<Subscriber>
+        {
+            public static readonly SubscriberComparer Instance = new SubscriberComparer();
+
+            public bool Equals(Subscriber x, Subscriber y)
+            {
+                return StringComparer.InvariantCulture.Compare(x.Endpoint, y.Endpoint) == 0 && StringComparer.InvariantCulture.Compare(x.TransportAddress, y.TransportAddress) == 0;
+            }
+
+            public int GetHashCode(Subscriber obj)
+            {
+                return (obj.Endpoint ?? string.Empty).Length;
+            }
         }
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureSubscriptionStorage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureSubscriptionStorage.cs
@@ -107,10 +107,8 @@
             foreach (var messageType in messageTypes)
             {
                 var name = messageType.TypeName;
-                var lastNameChar = name[name.Length - 1];
-                var nextChar = (char)(lastNameChar + 1);
                 var lowerBound = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, name);
-                var upperBound = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, name.Substring(0, name.Length - 1) + nextChar);
+                var upperBound = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, GetUpperBound(name));
                 var query = new TableQuery<Subscription>().Where(TableQuery.CombineFilters(lowerBound, "and", upperBound));
 
                 var subscriptions = await table.ExecuteQueryAsync(query).ConfigureAwait(false);
@@ -123,6 +121,11 @@
             }
 
             return subscribers;
+        }
+
+        static string GetUpperBound(string name)
+        {
+            return name + ", Version=z";
         }
 
         class SubscriberComparer : IEqualityComparer<Subscriber>


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/960

This fix changes the behavior of a direct query against the `PartitionKey` to the scan over a range or `PartitionKey`s. 

**Example**

Let's consider `MessageType` that is used to generate a `PartitionKey` equal to `Particular.Messages.IEvent, Version=2.3.4`. Before the fix, query targeted directly this partition key:
```
PartitionKey eq `Particular.Messages.IEvent, Version=2.3.4`
```

After the change the condition is changed to the range over partition key (mind the last character of the message type changed in the last clause)

```
(PartitionKey ge `Particular.Messages.IEvent`) and (PartitionKey lt `Particular.Messages.IEvenu`)
```