### PR TITLE
TimeoutPersister query operators fixed

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -164,9 +164,9 @@
                     .Where(
                         TableQuery.CombineFilters(
                             TableQuery.CombineFilters(
-                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.NotEqual, now.ToString(partitionKeyScope)),
+                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, now.ToString(partitionKeyScope)),
                                 TableOperators.And,
-                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.NotEqual, lastSuccessfulRead.Value.ToString(partitionKeyScope))),
+                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThan, lastSuccessfulRead.Value.ToString(partitionKeyScope))),
                             TableOperators.And,
                             TableQuery.GenerateFilterCondition("OwningTimeoutManager", QueryComparisons.Equal, endpointName))
                     );

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -153,7 +153,7 @@
             var timeoutDataTable = client.GetTableReference(timeoutDataTableName);
             var timeoutManagerDataTable = client.GetTableReference(timeoutManagerDataTableName);
 
-            await TryUpdateSuccessfulRead(timeoutManagerDataTable);
+            await TryUpdateSuccessfulRead(timeoutManagerDataTable).ConfigureAwait(false);
 
             var lastSuccessfulReadEntity = await GetLastSuccessfulRead(timeoutManagerDataTable).ConfigureAwait(false);
             var lastSuccessfulRead = lastSuccessfulReadEntity?.LastSuccessfullRead;
@@ -165,10 +165,9 @@
                 query = new TableQuery<TimeoutDataEntity>()
                     .Where(
                         TableQuery.CombineFilters(
-                            TableQuery.CombineFilters(
-                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThanOrEqual, now.ToString(partitionKeyScope)),
+                            TableQuery.CombineFilters(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, lastSuccessfulRead.Value.ToString(partitionKeyScope)),
                                 TableOperators.And,
-                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, lastSuccessfulRead.Value.ToString(partitionKeyScope))),
+                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThanOrEqual, now.ToString(partitionKeyScope))),
                             TableOperators.And,
                             TableQuery.GenerateFilterCondition("OwningTimeoutManager", QueryComparisons.Equal, endpointName))
                     );

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -164,9 +164,9 @@
                     .Where(
                         TableQuery.CombineFilters(
                             TableQuery.CombineFilters(
-                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, now.ToString(partitionKeyScope)),
+                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThanOrEqual, now.ToString(partitionKeyScope)),
                                 TableOperators.And,
-                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThan, lastSuccessfulRead.Value.ToString(partitionKeyScope))),
+                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, lastSuccessfulRead.Value.ToString(partitionKeyScope))),
                             TableOperators.And,
                             TableQuery.GenerateFilterCondition("OwningTimeoutManager", QueryComparisons.Equal, endpointName))
                     );

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -117,7 +117,7 @@
             }
             catch (StorageException e)
             {
-                if (e.RequestInformation.HttpStatusCode != (int) HttpStatusCode.NotFound)
+                if (e.RequestInformation.HttpStatusCode != (int)HttpStatusCode.NotFound)
                 {
                     throw;
                 }
@@ -152,6 +152,8 @@
 
             var timeoutDataTable = client.GetTableReference(timeoutDataTableName);
             var timeoutManagerDataTable = client.GetTableReference(timeoutManagerDataTableName);
+
+            await TryUpdateSuccessfulRead(timeoutManagerDataTable);
 
             var lastSuccessfulReadEntity = await GetLastSuccessfulRead(timeoutManagerDataTable).ConfigureAwait(false);
             var lastSuccessfulRead = lastSuccessfulReadEntity?.LastSuccessfullRead;
@@ -206,9 +208,23 @@
                     .ToArray(),
                 nextTimeToRunQuery);
 
-            await UpdateSuccessfulRead(timeoutManagerDataTable, lastSuccessfulReadEntity).ConfigureAwait(false);
-
+            updateSuccessfulReadOperationForNextSpin = GetUpdateSuccessfulRead(lastSuccessfulReadEntity);
             return timeoutsChunk;
+        }
+
+        async Task TryUpdateSuccessfulRead(CloudTable timeoutManagerDataTable)
+        {
+            if (updateSuccessfulReadOperationForNextSpin != null)
+            {
+                try
+                {
+                    await UpdateSuccessfulRead(timeoutManagerDataTable, updateSuccessfulReadOperationForNextSpin).ConfigureAwait(false);
+                }
+                finally
+                {
+                    updateSuccessfulReadOperationForNextSpin = null;
+                }
+            }
         }
 
         async Task DeleteMainEntity(CloudTable timeoutDataTable, string partitionKey, string rowKey)
@@ -333,7 +349,7 @@
                 await blob.DownloadToStreamAsync(stream).ConfigureAwait(false);
                 stream.Position = 0;
 
-                var buffer = new byte[16*1024];
+                var buffer = new byte[16 * 1024];
                 using (var ms = new MemoryStream())
                 {
                     int read;
@@ -386,22 +402,11 @@
             return results.SafeFirstOrDefault();
         }
 
-        Task UpdateSuccessfulRead(CloudTable table, TimeoutManagerDataEntity read)
+        static Task UpdateSuccessfulRead(CloudTable table, TableOperation operation)
         {
             try
             {
-                if (read == null)
-                {
-                    read = new TimeoutManagerDataEntity(sanitizedEndpointInstanceName, string.Empty)
-                    {
-                        LastSuccessfullRead = DateTime.UtcNow
-                    };
-
-                    var addOperation = TableOperation.Insert(read);
-                    return table.ExecuteAsync(addOperation);
-                }
-                var updateOperation = TableOperation.Replace(read);
-                return table.ExecuteAsync(updateOperation);
+                return table.ExecuteAsync(operation);
             }
             catch (DataServiceRequestException ex) // handle concurrency issues
             {
@@ -420,6 +425,28 @@
             }
         }
 
+        TableOperation GetUpdateSuccessfulRead(TimeoutManagerDataEntity read)
+        {
+            if (read == null)
+            {
+                read = new TimeoutManagerDataEntity(sanitizedEndpointInstanceName, string.Empty)
+                {
+                    LastSuccessfullRead = DateTime.UtcNow
+                };
+
+                return TableOperation.Insert(read);
+            }
+
+            var updated = new TimeoutManagerDataEntity(sanitizedEndpointInstanceName, string.Empty)
+            {
+                ETag = read.ETag,
+                Timestamp = read.Timestamp,
+                LastSuccessfullRead = read.LastSuccessfullRead
+            };
+
+            return TableOperation.Replace(updated);
+        }
+
         string timeoutDataTableName;
         string timeoutManagerDataTableName;
         string timeoutStateContainerName;
@@ -429,5 +456,6 @@
         string sanitizedEndpointInstanceName;
         CloudTableClient client;
         CloudBlobClient cloudBlobclient;
+        TableOperation updateSuccessfulReadOperationForNextSpin;
     }
 }


### PR DESCRIPTION
This PR changes the operators for querying timeout bringing it back to `>=` and `<=`.

This PR fixes the operators to its original shape before https://github.com/Particular/NServiceBus.Persistence.AzureStorage/commit/240e24e5e849981cbc022ff1279ba0015998ee91

Somehow connected to #118

PoA:
- [x] fix operators
- [x] ~possibly remove `TimeoutManagerDataEntity` as it looks like uneeded. It might be just a field in the timeout manager restored at the start of the endpoint. If needed, provide reasoning.~
- [x] move storing the cursor (`LastSuccesfulRead`) to the next spin of `GetChunk` to not move cursor beyond timeouts that weren't acknowledged yet.