### PR TITLE
Simplify and further restrict timeout query fix

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -158,7 +158,7 @@
             var lastSuccessfulReadEntity = await GetLastSuccessfulRead(timeoutManagerDataTable).ConfigureAwait(false);
             var lastSuccessfulRead = lastSuccessfulReadEntity?.LastSuccessfullRead;
 
-            var floor = lastSuccessfulRead ?? DateTime.MinValue;
+            var floor = lastSuccessfulRead ?? DateTime.UtcNow.AddYears(-1);
 
             var query = new TableQuery<TimeoutDataEntity>()
                 .Where(

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -158,25 +158,23 @@
             var lastSuccessfulReadEntity = await GetLastSuccessfulRead(timeoutManagerDataTable).ConfigureAwait(false);
             var lastSuccessfulRead = lastSuccessfulReadEntity?.LastSuccessfullRead;
 
-            TableQuery<TimeoutDataEntity> query;
+            var floor = lastSuccessfulRead ?? DateTime.MinValue;
 
-            if (lastSuccessfulRead.HasValue)
-            {
-                query = new TableQuery<TimeoutDataEntity>()
-                    .Where(
+            var query = new TableQuery<TimeoutDataEntity>()
+                .Where(
+                    TableQuery.CombineFilters(
                         TableQuery.CombineFilters(
-                            TableQuery.CombineFilters(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, lastSuccessfulRead.Value.ToString(partitionKeyScope)),
-                                TableOperators.And,
-                                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThanOrEqual, now.ToString(partitionKeyScope))),
+                            TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, floor.ToString(partitionKeyScope)),
                             TableOperators.And,
-                            TableQuery.GenerateFilterCondition("OwningTimeoutManager", QueryComparisons.Equal, endpointName))
-                    );
-            }
-            else
-            {
-                query = new TableQuery<TimeoutDataEntity>()
-                    .Where(TableQuery.GenerateFilterCondition("OwningTimeoutManager", QueryComparisons.Equal, endpointName));
-            }
+                            TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThanOrEqual, now.ToString(partitionKeyScope))),
+                        TableOperators.And,
+                        TableQuery.CombineFilters(
+                            TableQuery.GenerateFilterCondition("OwningTimeoutManager", QueryComparisons.Equal, endpointName),
+                            TableOperators.And,
+                            TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.NotEqual, string.Empty) //Remove the non-date primary key records
+                        )
+                    )
+                );
 
             var timeoutDataEntities = await timeoutDataTable.ExecuteQueryAsync(query, take: 1000).ConfigureAwait(false);
             var result = timeoutDataEntities.OrderBy(c => c.Time);


### PR DESCRIPTION
This PR simplifies the query assignment and adds additional restrictions on the valid primary keys when `lastSuccessFullRead` is not found.

The greater than / less than primary key conditions will still return some extra rows where the timeoutid or sagaid guid value falls within the string sort range of the conditional dates, this will just reduce the number of extra rows returned. The latter part of the function will further eliminate them.