### PR TITLE
Switching to upper bound query in TimeoutPersister and removing LastSuccessfulRead entities

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/APIApprovals.Approve.approved.txt
@@ -33,11 +33,15 @@ namespace NServiceBus
     }
     public class static ConfigureAzureTimeoutStorage
     {
+        [System.ObsoleteAttribute("The catchUpInterval is no longer used. Will be treated as an error from version 2" +
+            ".0.0. Will be removed in version 3.0.0.", false)]
         public static NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> CatchUpInterval(this NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> config, int catchUpInterval) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> ConnectionString(this NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> config, string connectionString) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> CreateSchema(this NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> config, bool createSchema) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> PartitionKeyScope(this NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> config, string partitionKeyScope) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> TimeoutDataTableName(this NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> config, string tableName) { }
+        [System.ObsoleteAttribute("The timeout manager table is no longer used. Will be treated as an error from ver" +
+            "sion 2.0.0. Will be removed in version 3.0.0.", false)]
         public static NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> TimeoutManagerDataTableName(this NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> config, string tableName) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> TimeoutStateContainerName(this NServiceBus.PersistenceExtensions<NServiceBus.AzureStoragePersistence, NServiceBus.Persistence.StorageType.Timeouts> config, string blobName) { }
     }

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Subscriptions\When_unsubscribing.cs" />
     <Compile Include="Subscriptions\When_updating_subscription.cs" />
     <Compile Include="Timeouts\TestHelper.cs" />
+    <Compile Include="Timeouts\When_querying_timeouts_via_persister_API.cs" />
     <Compile Include="Timeouts\When_querying_timeouts.cs" />
     <Compile Include="Timeouts\When_removing_timeouts_from_the_storage.cs" />
     <Compile Include="Timeouts\When_there_is_lots_of_future_timeouts.cs" />

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Subscriptions\When_unsubscribing.cs" />
     <Compile Include="Subscriptions\When_updating_subscription.cs" />
     <Compile Include="Timeouts\TestHelper.cs" />
+    <Compile Include="Timeouts\When_querying_timeouts.cs" />
     <Compile Include="Timeouts\When_removing_timeouts_from_the_storage.cs" />
     <Compile Include="Timeouts\When_there_is_lots_of_future_timeouts.cs" />
     <Compile Include="Timeouts\When_timeout_is_added.cs" />

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Subscriptions\When_updating_subscription.cs" />
     <Compile Include="Timeouts\TestHelper.cs" />
     <Compile Include="Timeouts\When_removing_timeouts_from_the_storage.cs" />
+    <Compile Include="Timeouts\When_there_is_lots_of_future_timeouts.cs" />
     <Compile Include="Timeouts\When_timeout_is_added.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Persisters/When_using_GlobalConnectionStringConfiguration.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Persisters/When_using_GlobalConnectionStringConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Persisters
 {
+    using Config;
     using Configuration.AdvanceExtensibility;
     using NUnit.Framework;
     using NServiceBus;
@@ -18,9 +19,9 @@
 
             var settings = persistence.GetSettings();
 
-            Assert.AreEqual(connectionString, settings.Get<string>("AzureSagaStorage.ConnectionString"));
-            Assert.AreEqual(connectionString, settings.Get<string>("AzureSubscriptionStorage.ConnectionString"));
-            Assert.AreEqual(connectionString, settings.Get<string>("AzureTimeoutStorage.ConnectionString"));
+            Assert.AreEqual(connectionString, settings.Get<string>(WellKnownConfigurationKeys.SagaStorageConnectionString));
+            Assert.AreEqual(connectionString, settings.Get<string>(WellKnownConfigurationKeys.SubscriptionStorageConnectionString));
+            Assert.AreEqual(connectionString, settings.Get<string>(WellKnownConfigurationKeys.TimeoutStorageConnectionString));
         }
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/TestHelper.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/TestHelper.cs
@@ -9,13 +9,12 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.RetryPolicies;
     using Microsoft.WindowsAzure.Storage.Table;
-    using Support;
     using Timeout.Core;
     using NUnit.Framework;
 
     static class TestHelper
     {
-        const string EndpointName = "Sales";
+        public const string EndpointName = "Sales";
 
         internal static TimeoutPersister CreateTimeoutPersister()
         {
@@ -23,9 +22,8 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
             try
             {
                 persister = new TimeoutPersister(AzurePersistenceTests.GetConnectionString(),
-                    AzureTimeoutStorageDefaults.TimeoutDataTableName, AzureTimeoutStorageDefaults.TimeoutManagerDataTableName,
-                    AzureTimeoutStorageDefaults.TimeoutStateContainerName, 3600,
-                    AzureTimeoutStorageDefaults.PartitionKeyScope, EndpointName, RuntimeEnvironment.MachineName);
+                    AzureTimeoutStorageDefaults.TimeoutDataTableName, AzureTimeoutStorageDefaults.TimeoutStateContainerName,
+                    AzureTimeoutStorageDefaults.PartitionKeyScope, EndpointName);
             }
             catch (WebException exception)
             {
@@ -99,7 +97,6 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
         internal static void PerformStorageCleanup()
         {
             RemoveAllRowsForTable(AzureTimeoutStorageDefaults.TimeoutDataTableName);
-            RemoveAllRowsForTable(AzureTimeoutStorageDefaults.TimeoutManagerDataTableName);
 
             RemoveAllBlobs();
         }

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/TestHelper.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/TestHelper.cs
@@ -97,8 +97,8 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
 
         public static async Task AssertAllTimeoutsThatHaveBeenRemoved(TimeoutPersister timeoutPersister)
         {
-            var timeouts = await timeoutPersister.GetNextChunk(DateTime.Now.AddYears(-3));
-            Assert.IsFalse(timeouts.DueTimeouts.Any());
+            var timeouts = await GetAllTimeoutsRaw();
+            CollectionAssert.IsEmpty(timeouts);
         }
 
         internal static Task PerformStorageCleanup()

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureStoragePersistence")]
+    public class When_querying_timeouts
+    {
+        [Test]
+        public void Returns_no_timeouts_when_none_exist()
+        {
+
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts.cs
@@ -25,7 +25,7 @@
         }
 
         [Test]
-        public async Task Returns_all_if_all_are_current_and_within_batch_size()
+        public async Task Returns_all_if_due_timeouts_are_current_and_within_batch_size()
         {
             var now = DateTime.Now;
             var segment1 = new List<TimeoutDataEntity> { CreateCurrentTimeout(now) };
@@ -35,6 +35,33 @@
 
             AssertEqual(segment1, results);
             Assert.AreEqual(now.Add(TimeoutPersister.DefaultNextQueryDelay), results.NextTimeToQuery);
+        }
+
+        [Test]
+        public async Task Returns_all_if_due_timeouts_are_returned_in_two_segments()
+        {
+            var now = DateTime.Now;
+            var segment1 = new List<TimeoutDataEntity> { CreateCurrentTimeout(now) };
+            var segment2 = new List<TimeoutDataEntity> { CreateCurrentTimeout(now) };
+            var executor = CreateQueryExecutor(segment1, segment2);
+
+            var results = await TimeoutPersister.CalculateNextTimeoutChunk(executor, null, now);
+
+            AssertEqual(segment1.Union(segment2), results);
+            Assert.AreEqual(now.Add(TimeoutPersister.DefaultNextQueryDelay), results.NextTimeToQuery);
+        }
+
+        [Test]
+        public async Task Returns_only_due_timeouts_from_single_segment()
+        {
+            var now = DateTime.Now;
+            var segment1 = new List<TimeoutDataEntity> { CreateCurrentTimeout(now), CreateFutrueTimeout(now) };
+            var executor = CreateQueryExecutor(segment1);
+
+            var results = await TimeoutPersister.CalculateNextTimeoutChunk(executor, null, now);
+
+            AssertEqual(segment1.Take(1), results);
+            Assert.AreEqual(segment1[1].Time, results.NextTimeToQuery);
         }
 
         static void AssertEqual(IEnumerable<TimeoutDataEntity> segment1, TimeoutsChunk results)
@@ -47,6 +74,13 @@
             return new TimeoutDataEntity { Time = now.AddSeconds(-1), RowKey = Guid.NewGuid().ToString()};
         }
 
+        static TimeoutDataEntity CreateFutrueTimeout(DateTime now)
+        {
+            return new TimeoutDataEntity { Time = now.AddMinutes(10), RowKey = Guid.NewGuid().ToString()};
+        }
+
+
+
         static Func<TableQuery<TimeoutDataEntity>, TableContinuationToken, Task<TableQuerySegment<TimeoutDataEntity>>> CreateQueryExecutor(params List<TimeoutDataEntity>[] values)
         {
             var counter = 0;
@@ -57,9 +91,11 @@
                     throw new Exception("Too many calls to provider");
                 }
 
-                var results = values[counter++];
+                var results = values[counter];
+
                 counter += 1;
-                return Task.FromResult(CreateSegment(results, null));
+
+                return Task.FromResult(CreateSegment(results, counter >= values.Length ? null : new TableContinuationToken()));
             };
         }
 

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts.cs
@@ -1,15 +1,76 @@
 ﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Microsoft.WindowsAzure.Storage.Table;
     using NUnit.Framework;
+    using Timeout.Core;
 
     [TestFixture]
     [Category("AzureStoragePersistence")]
     public class When_querying_timeouts
     {
         [Test]
-        public void Returns_no_timeouts_when_none_exist()
+        public async Task Returns_no_timeouts_when_none_exist()
         {
+            var now = DateTime.Now;
+            var executor = CreateQueryExecutor(new List<TimeoutDataEntity>());
+            var results = await TimeoutPersister.CalculateNextTimeoutChunk(executor, null, now);
 
+            CollectionAssert.IsEmpty(results.DueTimeouts);
+            Assert.AreEqual(now.Add(TimeoutPersister.DefaultNextQueryDelay), results.NextTimeToQuery);
+        }
+
+        [Test]
+        public async Task Returns_all_if_all_are_current_and_within_batch_size()
+        {
+            var now = DateTime.Now;
+            var segment1 = new List<TimeoutDataEntity> { CreateCurrentTimeout(now) };
+            var executor = CreateQueryExecutor(segment1);
+
+            var results = await TimeoutPersister.CalculateNextTimeoutChunk(executor, null, now);
+
+            AssertEqual(segment1, results);
+            Assert.AreEqual(now.Add(TimeoutPersister.DefaultNextQueryDelay), results.NextTimeToQuery);
+        }
+
+        static void AssertEqual(IEnumerable<TimeoutDataEntity> segment1, TimeoutsChunk results)
+        {
+            CollectionAssert.AreEquivalent(segment1.Select(s => s.RowKey), results.DueTimeouts.Select(t => t.Id));
+        }
+
+        static TimeoutDataEntity CreateCurrentTimeout(DateTime now)
+        {
+            return new TimeoutDataEntity { Time = now.AddSeconds(-1), RowKey = Guid.NewGuid().ToString()};
+        }
+
+        static Func<TableQuery<TimeoutDataEntity>, TableContinuationToken, Task<TableQuerySegment<TimeoutDataEntity>>> CreateQueryExecutor(params List<TimeoutDataEntity>[] values)
+        {
+            var counter = 0;
+            return (query, token) =>
+            {
+                if (counter >= values.Length)
+                {
+                    throw new Exception("Too many calls to provider");
+                }
+
+                var results = values[counter++];
+                counter += 1;
+                return Task.FromResult(CreateSegment(results, null));
+            };
+        }
+
+        static TableQuerySegment<TimeoutDataEntity> CreateSegment(List<TimeoutDataEntity> list, TableContinuationToken token)
+        {
+            var segment = (TableQuerySegment<TimeoutDataEntity>)Activator.CreateInstance(typeof(TableQuerySegment<TimeoutDataEntity>), BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance | BindingFlags.NonPublic, null, new[] { list }, null, null);
+            typeof(TableQuerySegment<TimeoutDataEntity>).GetProperty("ContinuationToken").GetSetMethod(true).Invoke(segment, new[]
+            {
+                token
+            });
+            return segment;
         }
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts_via_persister_API.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts_via_persister_API.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("AzureStoragePersistence")]
+    public class When_querying_timeouts_via_persister_API
+    {
+        [SetUp]
+        public Task Perform_storage_cleanup()
+        {
+            return TestHelper.PerformStorageCleanup();
+        }
+
+        [Test]
+        public async Task Returns_stored_timeout_via_GetNextChunk()
+        {
+            var now = new DateTime(2017, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+
+            var persister = TestHelper.CreateTimeoutPersister();
+            persister.NowGetter = () => now;
+
+            var timeout = TestHelper.GenerateTimeoutWithHeaders();
+            timeout.Time = now;
+
+            await persister.Add(timeout, new ContextBag()).ConfigureAwait(false);
+            var timeouts = await persister.GetNextChunk(DateTime.MinValue).ConfigureAwait(false);
+
+            Assert.AreEqual(timeout.Id, timeouts.DueTimeouts.Single().Id);
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts_via_persister_API.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_querying_timeouts_via_persister_API.cs
@@ -23,7 +23,7 @@
             var now = new DateTime(2017, 1, 1, 1, 1, 1, DateTimeKind.Utc);
 
             var persister = TestHelper.CreateTimeoutPersister();
-            persister.NowGetter = () => now;
+            persister.CurrentDateTimeProvider = () => now;
 
             var timeout = TestHelper.GenerateTimeoutWithHeaders();
             timeout.Time = now;
@@ -35,12 +35,12 @@
         }
 
         [Test]
-        public async Task Returns_tail_timeouts_when_GetNextChunk_till_they_exist()
+        public async Task Returns_all_timeouts_via_GetNextChunk_when_called_sufficient_number_of_times()
         {
             var now = new DateTime(2017, 1, 1, 1, 1, 1, DateTimeKind.Utc);
 
             var persister = TestHelper.CreateTimeoutPersister();
-            persister.NowGetter = () => now;
+            persister.CurrentDateTimeProvider = () => now;
 
             var tailTimeout = TestHelper.GenerateTimeoutWithHeaders();
             tailTimeout.Time = now.AddDays(-1);

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_removing_timeouts_from_the_storage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_removing_timeouts_from_the_storage.cs
@@ -24,7 +24,7 @@
             var timeout = TestHelper.GenerateTimeoutWithHeaders();
             await timeoutPersister.Add(timeout, null);
 
-            var timeouts = await TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            var timeouts = await TestHelper.GetAllTimeoutsRaw();
 
             Assert.True(timeouts.Count == 1);
 
@@ -40,7 +40,7 @@
             var timeout = TestHelper.GenerateTimeoutWithHeaders();
             await timeoutPersister.Add(timeout, null);
 
-            var timeouts = await TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            var timeouts = await TestHelper.GetAllTimeoutsRaw();
 
             Assert.AreEqual(timeouts.Count, 1);
 
@@ -73,7 +73,7 @@
             await timeoutPersister.Add(timeout1, null);
             await timeoutPersister.Add(timeout2, null);
 
-            var timeouts = await TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            var timeouts = await TestHelper.GetAllTimeoutsRaw();
             Assert.IsTrue(timeouts.Count == 2);
 
             var itemRemoved = true;
@@ -95,7 +95,7 @@
             var timeout = TestHelper.GenerateTimeoutWithHeaders();
             await timeoutPersister.Add(timeout, null);
 
-            var timeouts = await TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            var timeouts = await TestHelper.GetAllTimeoutsRaw();
             Assert.IsTrue(timeouts.Count == 1);
 
             var timeoutId = timeouts.First().Item1;
@@ -115,7 +115,7 @@
             await timeoutPersister.Add(timeout1, null);
             await timeoutPersister.Add(timeout2, null);
 
-            var timeouts = await TestHelper.GetAllTimeoutsUsingGetNextChunk(timeoutPersister);
+            var timeouts = await TestHelper.GetAllTimeoutsRaw();
             Assert.IsTrue(timeouts.Count == 2);
 
             await timeoutPersister.RemoveTimeoutBy(sagaId1, null);

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_removing_timeouts_from_the_storage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_removing_timeouts_from_the_storage.cs
@@ -11,9 +11,9 @@
     public class When_removing_timeouts_from_the_storage
     {
         [SetUp]
-        public void Perform_storage_cleanup()
+        public Task Perform_storage_cleanup()
         {
-            TestHelper.PerformStorageCleanup();
+            return TestHelper.PerformStorageCleanup();
         }
 
         [Test]

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_there_is_lots_of_future_timeouts.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_there_is_lots_of_future_timeouts.cs
@@ -2,9 +2,11 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Threading.Tasks;
     using Extensibility;
     using NUnit.Framework;
+    using NUnit.Framework.Compatibility;
     using Timeout.Core;
 
     [TestFixture]
@@ -19,15 +21,21 @@
             return TestHelper.PerformStorageCleanup();
         }
 
-        [Test]
+        [Test, Explicit("Used to check what is performance of GetNextChunk with considerable number of timeout rows outside of query criteria")]
         public async Task Should_return_timeouts_to_dispatch_reasonably_fast()
         {
+            ServicePointManager.DefaultConnectionLimit = 100;
+            ServicePointManager.UseNagleAlgorithm = false;
+            ServicePointManager.Expect100Continue = false;
+
             var timeoutPersister = TestHelper.CreateTimeoutPersister();
-            
+
             var future = DateTime.UtcNow.AddDays(1);
 
-            const int count = 100;
+            const int count = 1000;
             var tasks = new Task[count];
+
+            var insertStopWatch = Stopwatch.StartNew();
 
             for (var i = 0; i < count; i++)
             {
@@ -38,11 +46,18 @@
             }
 
             await Task.WhenAll(tasks);
+            var insertElapsed = insertStopWatch.ElapsedMilliseconds;
+
+            Console.WriteLine($"Insert took {insertElapsed} ms.");
 
             var outlier = DateTime.UtcNow.AddDays(-1);
             await timeoutPersister.Add(GenerateTimeout(outlier), new ContextBag());
 
+            var stopwatch = Stopwatch.StartNew();
             var peekedTimeout = await timeoutPersister.GetNextChunk(WhateverDate);
+            var elapsed = stopwatch.ElapsedMilliseconds;
+
+            Console.WriteLine($"GetNextChunk took {elapsed} ms.");
 
             Assert.AreEqual(1, peekedTimeout.DueTimeouts.Length);
             Assert.AreEqual(outlier, peekedTimeout.DueTimeouts[0].DueTime);

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_there_is_lots_of_future_timeouts.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_there_is_lots_of_future_timeouts.cs
@@ -1,0 +1,66 @@
+﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+    using Timeout.Core;
+
+    [TestFixture]
+    [Category("AzureStoragePersistence")]
+    public class When_there_is_lots_of_future_timeouts
+    {
+        static readonly DateTime WhateverDate = DateTime.Now;
+
+        [SetUp]
+        public void Perform_storage_cleanup()
+        {
+            TestHelper.PerformStorageCleanup();
+        }
+
+        [Test]
+        public async Task Should_return_timeouts_to_dispatch_reasonably_fast()
+        {
+            var timeoutPersister = TestHelper.CreateTimeoutPersister();
+            
+            var future = DateTime.UtcNow.AddDays(1);
+
+            const int count = 1;
+            var tasks = new Task[count];
+
+            for (var i = 0; i < count; i++)
+            {
+                var t = GenerateTimeout(future);
+
+                tasks[i] = timeoutPersister.Add(t, new ContextBag());
+                future = future.AddHours(1);
+            }
+
+            await Task.WhenAll(tasks);
+
+            var outlier = DateTime.UtcNow.AddDays(-1);
+            await timeoutPersister.Add(GenerateTimeout(outlier), new ContextBag());
+
+            var peekedTimeout = await timeoutPersister.GetNextChunk(WhateverDate);
+
+            Assert.AreEqual(1, peekedTimeout.DueTimeouts.Length);
+            Assert.AreEqual(outlier, peekedTimeout.DueTimeouts[0].DueTime);
+
+            TestHelper.PerformStorageCleanup();
+        }
+
+        static TimeoutData GenerateTimeout(DateTime time)
+        {
+            return new TimeoutData
+            {
+                Time = time,
+                Id = Guid.NewGuid().ToString(),
+                Destination = "whatever",
+                Headers = new Dictionary<string, string>(),
+                OwningTimeoutManager = TestHelper.EndpointName,
+                State = new byte[0],
+            };
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_there_is_lots_of_future_timeouts.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_there_is_lots_of_future_timeouts.cs
@@ -14,9 +14,9 @@
         static readonly DateTime WhateverDate = DateTime.Now;
 
         [SetUp]
-        public void Perform_storage_cleanup()
+        public Task Perform_storage_cleanup()
         {
-            TestHelper.PerformStorageCleanup();
+            return TestHelper.PerformStorageCleanup();
         }
 
         [Test]
@@ -26,7 +26,7 @@
             
             var future = DateTime.UtcNow.AddDays(1);
 
-            const int count = 1;
+            const int count = 100;
             var tasks = new Task[count];
 
             for (var i = 0; i < count; i++)
@@ -47,7 +47,7 @@
             Assert.AreEqual(1, peekedTimeout.DueTimeouts.Length);
             Assert.AreEqual(outlier, peekedTimeout.DueTimeouts[0].DueTime);
 
-            TestHelper.PerformStorageCleanup();
+            await TestHelper.PerformStorageCleanup();
         }
 
         static TimeoutData GenerateTimeout(DateTime time)

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_timeout_is_added.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Timeouts/When_timeout_is_added.cs
@@ -8,9 +8,9 @@
     public class When_timeout_is_added
     {
         [SetUp]
-        public void Perform_storage_cleanup()
+        public Task Perform_storage_cleanup()
         {
-            TestHelper.PerformStorageCleanup();
+            return TestHelper.PerformStorageCleanup();
         }
 
         [Test]
@@ -24,7 +24,7 @@
 
             Assert.AreEqual(timeout.State, peekedTimeout.State);
 
-            TestHelper.PerformStorageCleanup();
+            await TestHelper.PerformStorageCleanup();
         }
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/Config/WellKnownConfigurationKeys.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Config/WellKnownConfigurationKeys.cs
@@ -4,9 +4,7 @@
     {
         public const string TimeoutStorageConnectionString = "AzureTimeoutStorage.ConnectionString";
         public const string TimeoutStorageCreateSchema = "AzureTimeoutStorage.CreateSchema";
-        public const string TimeoutStorageTimeoutManagerDataTableName = "AzureTimeoutStorage.TimeoutManagerDataTableName";
         public const string TimeoutStorageTimeoutDataTableName = "AzureTimeoutStorage.TimeoutDataTableName";
-        public const string TimeoutStorageCatchUpInterval = "AzureTimeoutStorage.CatchUpInterval";
         public const string TimeoutStoragePartitionKeyScope = "AzureTimeoutStorage.PartitionKeyScope";
         public const string TimeoutStorageTimeoutStateContainerName = "AzureTimeoutStorage.TimeoutStateContainerName";
         public const string SagaStorageConnectionString = "AzureSagaStorage.ConnectionString";

--- a/src/NServiceBus.Persistence.AzureStorage/ConfigureAzureStorage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/ConfigureAzureStorage.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using Configuration.AdvanceExtensibility;
+    using Persistence.AzureStorage.Config;
 
     /// <summary>
     /// Configuration extensions for all Azure storage settings
@@ -17,9 +18,9 @@
             AzureStorageSagaGuard.CheckConnectionString(connectionString);
 
             var settings = config.GetSettings();
-            settings.Set("AzureSagaStorage.ConnectionString", connectionString);
-            settings.Set("AzureSubscriptionStorage.ConnectionString", connectionString);
-            settings.Set("AzureTimeoutStorage.ConnectionString", connectionString);
+            settings.Set(WellKnownConfigurationKeys.SagaStorageConnectionString, connectionString);
+            settings.Set(WellKnownConfigurationKeys.SubscriptionStorageConnectionString, connectionString);
+            settings.Set(WellKnownConfigurationKeys.TimeoutStorageConnectionString, connectionString);
 
             return config;
         }

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/ConfigureAzureSagaStorage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/ConfigureAzureSagaStorage.cs
@@ -2,6 +2,7 @@
 {
     using Configuration.AdvanceExtensibility;
     using Persistence;
+    using Persistence.AzureStorage.Config;
 
     //TODO
 
@@ -17,7 +18,7 @@
         {
             AzureStorageSagaGuard.CheckConnectionString(connectionString);
 
-            config.GetSettings().Set("AzureSagaStorage.ConnectionString", connectionString);
+            config.GetSettings().Set(WellKnownConfigurationKeys.SagaStorageConnectionString, connectionString);
             return config;
         }
 
@@ -27,7 +28,7 @@
         /// </summary>
         public static PersistenceExtensions<AzureStoragePersistence, StorageType.Sagas> CreateSchema(this PersistenceExtensions<AzureStoragePersistence, StorageType.Sagas> config, bool createSchema)
         {
-            config.GetSettings().Set("AzureSagaStorage.CreateSchema", createSchema);
+            config.GetSettings().Set(WellKnownConfigurationKeys.SagaStorageCreateSchema, createSchema);
             return config;
         }
     }

--- a/src/NServiceBus.Persistence.AzureStorage/Subscriptions/ConfigureAzureSubscriptionStorage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Subscriptions/ConfigureAzureSubscriptionStorage.cs
@@ -2,6 +2,7 @@
 {
     using Configuration.AdvanceExtensibility;
     using Persistence;
+    using Persistence.AzureStorage.Config;
     using Subscriptions;
 
     /// <summary>
@@ -16,7 +17,7 @@
         {
             AzureSubscriptionStorageGuard.CheckConnectionString(connectionString);
 
-            config.GetSettings().Set("AzureSubscriptionStorage.ConnectionString", connectionString);
+            config.GetSettings().Set(WellKnownConfigurationKeys.SubscriptionStorageConnectionString, connectionString);
             return config;
         }
 
@@ -27,7 +28,7 @@
         {
             AzureSubscriptionStorageGuard.CheckTableName(tableName);
 
-            config.GetSettings().Set("AzureSubscriptionStorage.TableName", tableName);
+            config.GetSettings().Set(WellKnownConfigurationKeys.SubscriptionStorageTableName, tableName);
             return config;
         }
 
@@ -37,7 +38,7 @@
         /// </summary>
         public static PersistenceExtensions<AzureStoragePersistence, StorageType.Subscriptions> CreateSchema(this PersistenceExtensions<AzureStoragePersistence, StorageType.Subscriptions> config, bool createSchema)
         {
-            config.GetSettings().Set("AzureSubscriptionStorage.CreateSchema", createSchema);
+            config.GetSettings().Set(WellKnownConfigurationKeys.SubscriptionStorageCreateSchema, createSchema);
             return config;
         }
     }

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureStorageTimeoutPersistence.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureStorageTimeoutPersistence.cs
@@ -34,7 +34,6 @@ namespace NServiceBus
             var connectionString = context.Settings.Get<string>(WellKnownConfigurationKeys.TimeoutStorageConnectionString);
             var partitionKeyScope = context.Settings.Get<string>(WellKnownConfigurationKeys.TimeoutStoragePartitionKeyScope);
             var endpointName = context.Settings.EndpointName();
-            var hostDisplayName = context.Settings.GetOrDefault<string>("NServiceBus.HostInformation.DisplayName");
             var timeoutStateContainerName = context.Settings.GetOrDefault<string>(WellKnownConfigurationKeys.TimeoutStorageTimeoutStateContainerName);
 
             if (createIfNotExist)

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureTimeoutStorageDefaults.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureTimeoutStorageDefaults.cs
@@ -3,17 +3,9 @@
     class AzureTimeoutStorageDefaults
     {
         /// <summary>
-        /// Azure Storage table name for Timeout Manager Data. Default is 'TimeoutManagerDataTable'.
-        /// </summary>
-        public const string TimeoutManagerDataTableName = "TimeoutManagerDataTable";
-        /// <summary>
         /// Azure Storage table name for Timeout Data. Default is 'TimeoutDataTableName'.
         /// </summary>
         public const string TimeoutDataTableName = "TimeoutDataTableName";
-        /// <summary>
-        /// Catchup interval in seconds. Default is 1 hour (3600 seconds).
-        /// </summary>
-        public const int CatchUpInterval = 3600;
         /// <summary>
         /// DateTime format used for creating the Partition Key Scope value. Default value is 'yyyyMMddHH'.
         /// </summary>

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/ConfigureAzureTimeoutStorage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/ConfigureAzureTimeoutStorage.cs
@@ -2,6 +2,7 @@
 {
     using Configuration.AdvanceExtensibility;
     using Persistence;
+    using Persistence.AzureStorage.Config;
     using Timeout;
 
     /// <summary>
@@ -16,13 +17,13 @@
         {
             AzureTimeoutStorageGuard.CheckConnectionString(connectionString);
 
-            config.GetSettings().Set("AzureTimeoutStorage.ConnectionString", connectionString);
+            config.GetSettings().Set(WellKnownConfigurationKeys.TimeoutStorageConnectionString, connectionString);
             return config;
         }
 
         public static PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> TimeoutStateContainerName(this PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> config, string blobName)
         {
-            config.GetSettings().Set("AzureTimeoutStorage.TimeoutStateContainerName", blobName);
+            config.GetSettings().Set(WellKnownConfigurationKeys.TimeoutStorageTimeoutStateContainerName, blobName);
             return config;
         }
 
@@ -32,13 +33,14 @@
         /// </summary>
         public static PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> CreateSchema(this PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> config, bool createSchema)
         {
-            config.GetSettings().Set("AzureTimeoutStorage.CreateSchema", createSchema);
+            config.GetSettings().Set(WellKnownConfigurationKeys.TimeoutStorageCreateSchema, createSchema);
             return config;
         }
 
         /// <summary>
         /// Set the name of the table where the timeout manager stores it's internal state.
         /// </summary>
+        // TODO: needs to be obsoleted
         public static PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> TimeoutManagerDataTableName(this PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> config, string tableName)
         {
             AzureTimeoutStorageGuard.CheckTableName(tableName);
@@ -54,7 +56,7 @@
         {
             AzureTimeoutStorageGuard.CheckTableName(tableName);
 
-            config.GetSettings().Set("AzureTimeoutStorage.TimeoutDataTableName", tableName);
+            config.GetSettings().Set(WellKnownConfigurationKeys.TimeoutStorageTimeoutDataTableName, tableName);
             return config;
         }
 
@@ -63,6 +65,7 @@
         /// </summary>
         /// <param name="catchUpInterval">Catch up interval in seconds</param>
         /// <param name="config"></param>
+        // TODO: needs to be obsoleted
         public static PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> CatchUpInterval(this PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> config, int catchUpInterval)
         {
             AzureTimeoutStorageGuard.CheckCatchUpInterval(catchUpInterval);
@@ -81,7 +84,7 @@
         {
             AzureTimeoutStorageGuard.CheckPartitionKeyScope(partitionKeyScope);
 
-            config.GetSettings().Set("AzureTimeoutStorage.PartitionKeyScope", partitionKeyScope);
+            config.GetSettings().Set(WellKnownConfigurationKeys.TimeoutStoragePartitionKeyScope, partitionKeyScope);
             return config;
         }
     }

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/ConfigureAzureTimeoutStorage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/ConfigureAzureTimeoutStorage.cs
@@ -40,12 +40,12 @@
         /// <summary>
         /// Set the name of the table where the timeout manager stores it's internal state.
         /// </summary>
-        // TODO: needs to be obsoleted
+        [ObsoleteEx(
+         TreatAsErrorFromVersion = "2",
+         RemoveInVersion = "3",
+         Message = "The timeout manager table is no longer used.")]
         public static PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> TimeoutManagerDataTableName(this PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> config, string tableName)
         {
-            AzureTimeoutStorageGuard.CheckTableName(tableName);
-
-            config.GetSettings().Set("AzureTimeoutStorage.TimeoutManagerDataTableName", tableName);
             return config;
         }
 
@@ -65,12 +65,12 @@
         /// </summary>
         /// <param name="catchUpInterval">Catch up interval in seconds</param>
         /// <param name="config"></param>
-        // TODO: needs to be obsoleted
+        [ObsoleteEx(
+         TreatAsErrorFromVersion = "2",
+         RemoveInVersion = "3",
+         Message = "The catchUpInterval is no longer used.")]
         public static PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> CatchUpInterval(this PersistenceExtensions<AzureStoragePersistence, StorageType.Timeouts> config, int catchUpInterval)
         {
-            AzureTimeoutStorageGuard.CheckCatchUpInterval(catchUpInterval);
-
-            config.GetSettings().Set("AzureTimeoutStorage.CatchUpInterval", catchUpInterval);
             return config;
         }
 

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -189,6 +189,11 @@
 
             nextRequestTime = timeouts.Count < TimeoutChunkBatchSize && nextRequestTime != DateTime.MaxValue ? nextRequestTime : now.Add(DefaultNextQueryDelay);
 
+            if (nextRequestTime > now + MaximumDelay)
+            {
+                nextRequestTime = now + MaximumDelay;
+            }
+            
             return new TimeoutsChunk(dueTimeouts, nextRequestTime);
         }
 
@@ -359,6 +364,7 @@
         CloudTableClient client;
         CloudBlobClient cloudBlobclient;
         internal static readonly TimeSpan DefaultNextQueryDelay = TimeSpan.FromSeconds(1);
+        internal static readonly TimeSpan MaximumDelay = TimeSpan.FromMinutes(10);
         internal const int TimeoutChunkBatchSize = 1000;
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -162,7 +162,7 @@
             var timeouts = new List<TimeoutDataEntity>();
             TableContinuationToken token = null;
             var nextRequestTime = DateTime.MaxValue;
-
+            
             do
             {
                 var seg = await executeQuerySegmentedAsync(query, token).ConfigureAwait(false);
@@ -189,7 +189,7 @@
                 .Distinct(new TimoutChunkComparer())
                 .ToArray();
 
-            nextRequestTime = timeouts.Count < TimeoutChunkBatchSize ? nextRequestTime : DateTime.Now.Add(TimeSpan.FromSeconds(1));
+            nextRequestTime = timeouts.Count < TimeoutChunkBatchSize && nextRequestTime != DateTime.MaxValue ? nextRequestTime : now.Add(DefaultNextQueryDelay);
 
             return new TimeoutsChunk(dueTimeouts, nextRequestTime);
         }
@@ -359,5 +359,6 @@
         string endpointName;
         CloudTableClient client;
         CloudBlobClient cloudBlobclient;
+        internal static readonly TimeSpan DefaultNextQueryDelay = TimeSpan.FromSeconds(1);
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -162,7 +162,7 @@
                     // It is highly probable that this task will return before removing timeouts. This increases probability of duplicated.
                     // On the other hand timeouts are removed by the satellite which already introduces a lot of latency in dispatching regular timeouts.
                     longTailQuery = GetNextChunkImpl(QueryComparisons.LessThan);
-                    return new TimeoutsChunk(result.DueTimeouts, NowGetter());
+                    return new TimeoutsChunk(result.DueTimeouts, CurrentDateTimeProvider());
                 }
 
                 longTailQuery = GetLongTailTimeoutsDelayed();
@@ -179,7 +179,7 @@
 
         Task<TimeoutsChunk> GetNextChunkImpl(string partitionKeyComparison)
         {
-            var now = NowGetter();
+            var now = CurrentDateTimeProvider();
             var timeoutDataTable = client.GetTableReference(timeoutDataTableName);
 
             var query = new TableQuery<TimeoutDataEntity>()
@@ -193,7 +193,7 @@
             return CalculateNextTimeoutChunk((q, t) => timeoutDataTable.ExecuteQuerySegmentedAsync(q, t, new CancellationToken()), query, now);
         }
 
-        internal Func<DateTime> NowGetter { get; set; } = () => DateTime.UtcNow;
+        internal Func<DateTime> CurrentDateTimeProvider { get; set; } = () => DateTime.UtcNow;
 
         internal static async Task<TimeoutsChunk> CalculateNextTimeoutChunk(Func<TableQuery<TimeoutDataEntity>, TableContinuationToken, Task<TableQuerySegment<TimeoutDataEntity>>> executeQuerySegmentedAsync, TableQuery<TimeoutDataEntity> query, DateTime now)
         {

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -18,8 +18,6 @@
 
     class TimeoutPersister : IPersistTimeouts, IQueryTimeouts
     {
-        const int TimeoutChunkBatchSize = 1000;
-
         public TimeoutPersister(string timeoutConnectionString, string timeoutDataTableName, string timeoutStateContainerName, string partitionKeyScope, string endpointName)
         {
             this.timeoutDataTableName = timeoutDataTableName;
@@ -353,6 +351,7 @@
             return blob.DeleteIfExistsAsync();
         }
 
+
         string timeoutDataTableName;
         string timeoutStateContainerName;
         string partitionKeyScope;
@@ -360,5 +359,6 @@
         CloudTableClient client;
         CloudBlobClient cloudBlobclient;
         internal static readonly TimeSpan DefaultNextQueryDelay = TimeSpan.FromSeconds(1);
+        internal const int TimeoutChunkBatchSize = 1000;
     }
 }


### PR DESCRIPTION
Supersedes #121 

This PR switches from LastSuccessfulRead and uses only single upper bound query when retrieving next chunk of timeouts. 

It includes performance test trying to show that `GetNextChunk` performance is not affected by large amount of partition keys (a partial table scan with low number of partitions below the boundary). **We need to confirm this**.

PoA:
- [x] GetNextChunk querying only current partition
- [x] Tests should use a raw query against the storage 
- [x] asynchronous `tail query` for getting all the dangling timeouts in all the partitions before the current one

/cc: @Particular/azure-maintainers 