### PR TITLE
[WIP] Test detecting table scans during saga lifecycle

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/AzureRequestRecorder.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/AzureRequestRecorder.cs
@@ -1,0 +1,39 @@
+﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.WindowsAzure.Storage;
+
+    public class AzureRequestRecorder : IDisposable
+    {
+        public List<string> Requests = new List<string>();
+
+        public AzureRequestRecorder()
+        {
+            OperationContext.GlobalSendingRequest += OnSendingRequest;
+        }
+
+        void OnSendingRequest(object sender, RequestEventArgs e)
+        {
+            Requests.Add($"{e.Request.Method,-7} {e.Request.RequestUri.PathAndQuery}");
+        }
+
+        public void Dispose()
+        {
+            OperationContext.GlobalSendingRequest -= OnSendingRequest;
+        }
+
+        public void Print(TextWriter @out)
+        {
+            @out.WriteLine("Recorded calls to Azure Storage Services");
+
+            foreach (var request in Requests)
+            {
+                @out.WriteLine($"- {request}");
+            }
+
+            @out.WriteLine();
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/NServiceBus.Persistence.AzureStorage.ComponentTests.csproj
@@ -121,11 +121,13 @@
     <Compile Include="App_Packages\ApiApprover.6.0.0\PublicApiApprover.cs" />
     <Compile Include="App_Packages\PublicApiGenerator.6.0.0\ApiGenerator.cs" />
     <Compile Include="AzurePersistenceTests.cs" />
+    <Compile Include="AzureRequestRecorder.cs" />
     <Compile Include="Persisters\When_using_GlobalConnectionStringConfiguration.cs" />
     <Compile Include="Sagas\SecondaryIndexKeyBuilderTests.cs" />
     <Compile Include="Sagas\When_completing_saga.cs" />
     <Compile Include="Sagas\When_executing_concurrently.cs" />
     <Compile Include="Sagas\When_storying_saga_with_non_primitive_values.cs" />
+    <Compile Include="Sagas\When_working_with_saga_with_correlation_property.cs" />
     <Compile Include="Sagas\When_updating_saga.cs" />
     <Compile Include="Sagas\When_saving_saga.cs" />
     <Compile Include="Sagas\When_getting_the_saga_entity.cs" />

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Sagas/When_saving_saga.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Sagas/When_saving_saga.cs
@@ -22,12 +22,12 @@
 
             Assert.ThrowsAsync<StorageException>(async () => await persister.Save(saga, null, null, new ContextBag()));
         }
-    }
 
-    public class SaveSagaData : IContainSagaData
-    {
-        public Guid Id { get; set; }
-        public string Originator { get; set; }
-        public string OriginalMessageId { get; set; }
+        class SaveSagaData : IContainSagaData
+        {
+            public Guid Id { get; set; }
+            public string Originator { get; set; }
+            public string OriginalMessageId { get; set; }
+        }
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Sagas/When_working_with_saga_with_correlation_property.cs
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/Sagas/When_working_with_saga_with_correlation_property.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Persisters
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NServiceBus.Sagas;
+    using NUnit.Framework;
+
+    public class When_working_with_saga_with_correlation_property
+    {
+        const string CorrelationValue = "correlation-value";
+        const string UpdatedValue = "updated-value";
+
+        [Test]
+        public async Task Should_not_issue_table_scan()
+        {
+            var connectionString = AzurePersistenceTests.GetConnectionString();
+
+            // warm up table cache
+            var warmUp = new AzureSagaPersister(connectionString, true);
+            await warmUp.Get<SagaData>(Guid.NewGuid(), null, new ContextBag()).ConfigureAwait(false);
+
+            using (var recorder = new AzureRequestRecorder())
+            {
+                // save saga
+                {
+                    var saga = new SagaData
+                    {
+                        Id = Guid.NewGuid(),
+                        Originator = "Moo",
+                        OriginalMessageId = "MooId",
+                        Correlation = CorrelationValue
+                    };
+
+                    var persister = new AzureSagaPersister(connectionString, true);
+                    await persister.Save(saga, new SagaCorrelationProperty(nameof(SagaData.Correlation), CorrelationValue), null, new ContextBag()).ConfigureAwait(false);
+                }
+
+                // get by correlation and update
+                {
+                    var persister = new AzureSagaPersister(connectionString, true);
+                    var ctx = new ContextBag();
+
+                    var saga = await persister.Get<SagaData>(nameof(SagaData.Correlation), CorrelationValue, null, ctx).ConfigureAwait(false);
+                    saga.Value = UpdatedValue;
+
+                    await persister.Update(saga, null, ctx).ConfigureAwait(false);
+                }
+
+                // get by correlation and complete
+                {
+                    var persister = new AzureSagaPersister(connectionString, true);
+                    var ctx = new ContextBag();
+
+                    var saga = await persister.Get<SagaData>(nameof(SagaData.Correlation), CorrelationValue, null, ctx).ConfigureAwait(false);
+                    await persister.Complete(saga, null, ctx).ConfigureAwait(false);
+                }
+
+                recorder.Print(Console.Out);
+
+                var gets = recorder.Requests.Where(r => r.ToLower().Contains("get"));
+                var getsWithNoPartitionKey = gets.Where(get => get.Contains("PartitionKey") == false).ToArray();
+
+                // only asking for a table
+                CollectionAssert.IsEmpty(getsWithNoPartitionKey);
+            }
+        }
+    }
+
+    class SagaData : ContainSagaData
+    {
+        public string Value { get; set; }
+        public string Correlation { get; set; }
+    }
+}

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
@@ -74,8 +74,7 @@
 
         public async Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context)
         {
-            var tableName = sagaData.GetType().Name;
-            var table = client.GetTableReference(tableName);
+            var table = await GetTable(sagaData.GetType()).ConfigureAwait(false);
 
             var sagaId = sagaData.Id;
             var query = GenerateSagaTableQuery<DictionaryTableEntity>(sagaId);
@@ -140,8 +139,7 @@
 
         async Task<DictionaryTableEntity> GetDictionaryTableEntity(string sagaId, Type entityType)
         {
-            var tableName = entityType.Name;
-            var table = client.GetTableReference(tableName);
+            var table = await GetTable(entityType).ConfigureAwait(false);
 
             var query = new TableQuery<DictionaryTableEntity>().Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, sagaId));
 
@@ -196,8 +194,7 @@
                 "RowKey"
             };
 
-            var tableName = sagaType.Name;
-            var table = client.GetTableReference(tableName);
+            var table = await GetTable(sagaType).ConfigureAwait(false);
             var entities = await table.ExecuteQueryAsync(query).ConfigureAwait(false);
             return entities.Select(entity => Guid.ParseExact(entity.PartitionKey, "D")).ToArray();
         }


### PR DESCRIPTION
Connects to #130  ~~#132~~

This PR introduces a test that checks what queries are issued to the storage during regular lifetime. It asserts, that no table-scan query is issued (a query with no `PartitionKey`). The test removes the possibility of reusing cached secondary index value by recreating the `AzurePersister` before every step.