### PR TITLE
Release 1.2

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/app.config
+++ b/src/NServiceBus.Persistence.AzureStorage.AcceptanceTests/app.config
@@ -3,6 +3,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.1.1.0" newVersion="8.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>

--- a/src/NServiceBus.Persistence.AzureStorage.ComponentTests/app.config
+++ b/src/NServiceBus.Persistence.AzureStorage.ComponentTests/app.config
@@ -3,6 +3,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.1.1.0" newVersion="8.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>

--- a/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
@@ -68,8 +68,8 @@
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.8.1.1\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.8.0.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -77,7 +77,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.1.3\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.0.0\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Obsolete, Version=4.1.0.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03, processorArchitecture=MSIL">

--- a/src/NServiceBus.Persistence.AzureStorage/packages.config
+++ b/src/NServiceBus.Persistence.AzureStorage/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NServiceBus" version="6.1.3" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0" targetFramework="net452" />
   <package id="NuGetPackager" version="0.6.1" targetFramework="net452" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.1.0" targetFramework="net452" developmentDependency="true" />
   <package id="Particular.CodeRules" version="0.1.1" targetFramework="net452" developmentDependency="true" />
@@ -16,5 +16,5 @@
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net452" />
   <package id="System.Net.Requests" version="4.3.0" targetFramework="net452" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="8.1.1" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Connects to #135

Lowering the referenced packages in the storage library.
This follows the rule that:
- the library should reference the first major
- tests should reference the recent patch withing this major