### PR TITLE
Log a warning, don't throw for full .net framework

### DIFF
--- a/src/AcceptanceTests/BackwardsCompatibleQueueNameSanitizerForTests.cs
+++ b/src/AcceptanceTests/BackwardsCompatibleQueueNameSanitizerForTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+static class BackwardsCompatibleQueueNameSanitizerForTests
+{
+    public static string Sanitize(string queueName)
+    {
+        var queueNameInLowerCase = queueName.ToLowerInvariant();
+        return ShortenQueueNameIfNecessary(queueNameInLowerCase, SanitizeQueueName(queueNameInLowerCase));
+    }
+
+    static string ShortenQueueNameIfNecessary(string address, string queueName)
+    {
+        if (queueName.Length <= 63)
+        {
+            return queueName;
+        }
+
+        var shortenedName = ShortenWithMd5(address);
+        queueName = $"{queueName.Substring(0, 63 - shortenedName.Length - 1).Trim('-')}-{shortenedName}";
+        return queueName;
+    }
+
+    static string SanitizeQueueName(string queueName)
+    {
+        // this can lead to multiple - occurrences in a row
+        var sanitized = invalidCharacters.Replace(queueName, "-");
+        sanitized = multipleDashes.Replace(sanitized, "-");
+        return sanitized;
+    }
+
+    static Regex invalidCharacters = new Regex(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
+    static Regex multipleDashes = new Regex(@"\-+", RegexOptions.Compiled);
+
+    static string ShortenWithMd5(string test)
+    {
+        //use MD5 hash to get a 16-byte hash of the string
+        using (var provider = MD5.Create())
+        {
+            var inputBytes = Encoding.Default.GetBytes(test);
+            var hashBytes = provider.ComputeHash(inputBytes);
+            //generate a guid from the hash:
+            return new Guid(hashBytes).ToString();
+        }
+    }
+}

--- a/src/AcceptanceTests/ConfigureEndpointAzureStorageQueueTransport.cs
+++ b/src/AcceptanceTests/ConfigureEndpointAzureStorageQueueTransport.cs
@@ -18,6 +18,7 @@ public class ConfigureEndpointAzureStorageQueueTransport : IConfigureEndpointTes
             .ConnectionString(connectionString)
             .Routing();
 
+        transportConfig.SanitizeQueueNamesWith(BackwardsCompatibleQueueNameSanitizerForTests.Sanitize);
 
         foreach (var publisher in publisherMetadata.Publishers)
         {

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureStorageSagaPersistence.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureStorageSagaPersistence.cs
@@ -14,7 +14,10 @@
             {
 #if NET452
                 var defaultConnectionString = System.Configuration.ConfigurationManager.AppSettings["NServiceBus/Persistence"];
-                s.SetDefault(WellKnownConfigurationKeys.SagaStorageConnectionString, defaultConnectionString);
+                if (string.IsNullOrEmpty(defaultConnectionString) != true)
+                {
+                    logger.Warn(@"Connection string should be assigned using code API: var persistence = endpointConfiguration.UsePersistence<AzureStoragePersistence, StorageType.Timeouts>();\npersistence.ConnectionString(""connectionString"");");
+                }
 #endif
                 s.SetDefault(WellKnownConfigurationKeys.SagaStorageCreateSchema, AzureStorageSagaDefaults.CreateSchema);
                 s.SetDefault(WellKnownConfigurationKeys.SagaStorageAssumeSecondaryIndicesExist, AzureStorageSagaDefaults.AssumeSecondaryIndicesExist);
@@ -32,12 +35,12 @@
 
             if (assumeSecondaryIndicesExist == false)
             {
-                log.Warn($"The version of {nameof(AzureStoragePersistence)} used is not configured to optimize sagas creation. To enable optimization, use '.{nameof(ConfigureAzureSagaStorage.AssumeSecondaryIndicesExist)}()' configuration API.");
+                logger.Warn($"The version of {nameof(AzureStoragePersistence)} used is not configured to optimize sagas creation. To enable optimization, use '.{nameof(ConfigureAzureSagaStorage.AssumeSecondaryIndicesExist)}()' configuration API.");
             }
 
             context.Container.ConfigureComponent(builder => new AzureSagaPersister(connectionstring, updateSchema, assumeSecondaryIndicesExist), DependencyLifecycle.InstancePerCall);
         }
 
-        static ILog log = LogManager.GetLogger<AzureStorageSagaPersistence>();
+        static ILog logger = LogManager.GetLogger<AzureStorageSagaPersistence>();
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureStorageSubscriptionPersistence.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureStorageSubscriptionPersistence.cs
@@ -23,7 +23,7 @@ namespace NServiceBus
                 var defaultConnectionString = ConfigurationManager.AppSettings["NServiceBus/Persistence"];
                 if (string.IsNullOrEmpty(defaultConnectionString) != true)
                 {
-                    throw new Exception(@"Connection string should be assigned using code API: var persistence = endpointConfiguration.UsePersistence<AzureStoragePersistence, StorageType.Subscriptions>();\npersistence.ConnectionString(""connectionString"");");
+                    logger.Warn(@"Connection string should be assigned using code API: var persistence = endpointConfiguration.UsePersistence<AzureStoragePersistence, StorageType.Timeouts>();\npersistence.ConnectionString(""connectionString"");");
                 }
 #endif
                 s.SetDefault(WellKnownConfigurationKeys.SubscriptionStorageTableName, AzureSubscriptionStorageDefaults.TableName);
@@ -73,6 +73,7 @@ namespace NServiceBus
                 return Task.FromResult(0);
             }
         }
-    }
 
+        static ILog logger => LogManager.GetLogger<AzureStorageSubscriptionPersistence>();
+    }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureStorageSubscriptionPersistence.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureStorageSubscriptionPersistence.cs
@@ -1,9 +1,6 @@
 namespace NServiceBus
 {
     using System;
-#if NET452
-    using System.Configuration;
-#endif
     using System.Threading.Tasks;
     using Features;
     using Microsoft.WindowsAzure.Storage;
@@ -20,7 +17,7 @@ namespace NServiceBus
             Defaults(s =>
             {
 #if NET452
-                var defaultConnectionString = ConfigurationManager.AppSettings["NServiceBus/Persistence"];
+                var defaultConnectionString = System.Configuration.ConfigurationManager.AppSettings["NServiceBus/Persistence"];
                 if (string.IsNullOrEmpty(defaultConnectionString) != true)
                 {
                     logger.Warn(@"Connection string should be assigned using code API: var persistence = endpointConfiguration.UsePersistence<AzureStoragePersistence, StorageType.Timeouts>();\npersistence.ConnectionString(""connectionString"");");

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureStorageTimeoutPersistence.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureStorageTimeoutPersistence.cs
@@ -22,7 +22,7 @@ namespace NServiceBus
                 var defaultConnectionString = ConfigurationManager.AppSettings["NServiceBus/Persistence"];
                 if (string.IsNullOrEmpty(defaultConnectionString) != true)
                 {
-                    throw new Exception(@"Connection string should be assigned using code API: var persistence = endpointConfiguration.UsePersistence<AzureStoragePersistence, StorageType.Timeouts>();\npersistence.ConnectionString(""connectionString"");");
+                    logger.Warn(@"Connection string should be assigned using code API: var persistence = endpointConfiguration.UsePersistence<AzureStoragePersistence, StorageType.Timeouts>();\npersistence.ConnectionString(""connectionString"");");
                 }
 #endif
                 s.SetDefault(WellKnownConfigurationKeys.TimeoutStorageCreateSchema, AzureTimeoutStorageDefaults.CreateSchema);
@@ -99,5 +99,7 @@ namespace NServiceBus
                 return Task.FromResult(0);
             }
         }
+
+        static ILog logger => LogManager.GetLogger<AzureStorageTimeoutPersistence>();
     }
 }

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureStorageTimeoutPersistence.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureStorageTimeoutPersistence.cs
@@ -1,9 +1,5 @@
 namespace NServiceBus
 {
-#if NET452
-    using System;
-    using System.Configuration;
-#endif
     using System.Threading.Tasks;
     using Persistence.AzureStorage;
     using Features;
@@ -19,7 +15,7 @@ namespace NServiceBus
             Defaults(s =>
             {
 #if NET452
-                var defaultConnectionString = ConfigurationManager.AppSettings["NServiceBus/Persistence"];
+                var defaultConnectionString = System.Configuration.ConfigurationManager.AppSettings["NServiceBus/Persistence"];
                 if (string.IsNullOrEmpty(defaultConnectionString) != true)
                 {
                     logger.Warn(@"Connection string should be assigned using code API: var persistence = endpointConfiguration.UsePersistence<AzureStoragePersistence, StorageType.Timeouts>();\npersistence.ConnectionString(""connectionString"");");


### PR DESCRIPTION
Do not throw an exception for .NET full framework. Instead, log a warning instructing what should be done to be consistent with .NET Core and our future plans.

@Particular/azure-maintainers please review