### PR TITLE
Lower bound for core raised to beta5

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="WindowsAzure.Storage" Version="[8.2.0, 9.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0-*, 8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0005, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="4.*" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="All" />


### PR DESCRIPTION
Core beta5 has breaking changes. Due to that we need to up the lower range