### PR TITLE
Delaying a failed message can cause message loss

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -51,16 +51,8 @@
         {
             var timeoutDataTable = client.GetTableReference(timeoutDataTableName);
 
-            string identifier;
-            timeout.Headers.TryGetValue(Headers.MessageId, out identifier);
-            if (string.IsNullOrEmpty(identifier))
-            {
-                identifier = Guid.NewGuid().ToString();
-            }
+            var identifier = Guid.NewGuid().ToString();
             timeout.Id = identifier;
-
-            var timeoutDataEntity = await GetTimeoutData(timeoutDataTable, identifier, string.Empty).ConfigureAwait(false);
-            if (timeoutDataEntity != null) return;
 
             var headers = Serialize(timeout.Headers);
 


### PR DESCRIPTION
## Who's affected

If the following circumstances are given:

- A transport that doesn't support native delayed delivery
- The transport makes rolled back messages immediately visible in the queue
- The message processing fails and goes through delayed retries
- A race condition between the transport and the persister occurs

then you are affected. This is highly unlikely to happen with Azure Storage Queues due to network latency. Azure Service Bus is not affected either since it supports native delayed delivery.

## Symptoms

This causes the timeout not to be retried. Unfortunately, there is no log entry indicating that this bug occurred. 