### PR TITLE
Fix transitive dependency version issue for Microsoft.Data.Services.Client

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
@@ -19,15 +19,10 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\packaging\nuget\nservicebus.persistence.azurestorage.nuspec" Link="nservicebus.persistence.azurestorage.nuspec" />
-    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.0.4" />
-    <PackageReference Include="Microsoft.Data.Edm" Version="5.8.2" />
-    <PackageReference Include="Microsoft.Data.OData" Version="5.8.2" />
-    <PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="NServiceBus" Version="6.0.0" />
     <PackageReference Include="Obsolete.Fody" Version="4.2.2" />
-    <PackageReference Include="System.Spatial" Version="5.8.2" />
     <PackageReference Include="Fody" Version="2.1.0" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" />
     <PackageReference Include="NuGetPackager" Version="0.6.3" />


### PR DESCRIPTION
Fix transitive dependency version issue for Microsoft.Data.Services.Client caused by referencing it directly in csproj and causing discrepency when NServiceBus.Persistence.AzureStorage package is used.