### PR TITLE
Fixing ApprovalTests on a specific version

### DIFF
--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup Condition="$(TargetFramework) == 'net452'">
     <PackageReference Include="ObjectApproval" Version="1.*" />
-    <PackageReference Include="ApprovalTests" Version="3.*" />
+    <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="PublicApiGenerator" Version="6.*" />
   </ItemGroup>
 


### PR DESCRIPTION
This should fix the build of support-2.0