### PR TITLE
Remove unneeded async workaround in tests

### DIFF
--- a/src/Tests/Subscriptions/SubscriptionPersisterExtensions.cs
+++ b/src/Tests/Subscriptions/SubscriptionPersisterExtensions.cs
@@ -11,17 +11,5 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Subscriptions
         {
             return persister.GetSubscriberAddressesForMessage(messageHierarchy, null);
         }
-
-        /// <summary>Workaround for issue https://github.com/approvals/ApprovalTests.Net/issues/61</summary>
-        public static void AwaitFix(this Task task)
-        {
-            task.GetAwaiter().GetResult();
-        }
-
-        /// <summary>Workaround for issue https://github.com/approvals/ApprovalTests.Net/issues/61</summary>
-        public static T AwaitFix<T>(this Task<T> task)
-        {
-            return task.GetAwaiter().GetResult();
-        }
     }
 }

--- a/src/Tests/Subscriptions/When_caching.cs
+++ b/src/Tests/Subscriptions/When_caching.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Subscriptions
         {
             var persister = await SubscriptionTestHelper.CreateAzureSubscriptionStorage();
             var type = new MessageType("type1", new Version(0, 0, 0, 0));
-            persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type, null).AwaitFix();
+            await persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type, null);
             var first = Stopwatch.StartNew();
             var subscribersFirst = await persister.GetSubscribers(type)
                 .ConfigureAwait(false);
@@ -39,57 +39,57 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Subscriptions
         }
 
         [Test]
-        public void Should_be_cached()
+        public async Task Should_be_cached()
         {
-            var persister = SubscriptionTestHelper.CreateAzureSubscriptionStorage().AwaitFix();
+            var persister = await SubscriptionTestHelper.CreateAzureSubscriptionStorage();
             var type = new MessageType("type1", new Version(0, 0, 0, 0));
-            persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type, null).AwaitFix();
-            persister.GetSubscribers(type).AwaitFix();
+            await persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type, null);
+            await persister.GetSubscribers(type);
             VerifyCache(persister.Cache);
         }
 
         [Test]
-        public void Subscribe_with_same_type_should_clear_cache()
+        public async Task Subscribe_with_same_type_should_clear_cache()
         {
-            var persister = SubscriptionTestHelper.CreateAzureSubscriptionStorage().AwaitFix();
+            var persister = await SubscriptionTestHelper.CreateAzureSubscriptionStorage();
             var matchingType = new MessageType("matchingType", new Version(0, 0, 0, 0));
-            persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), matchingType, null).AwaitFix();
-            persister.GetSubscribers(matchingType).AwaitFix();
-            persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), matchingType, null).AwaitFix();
+            await persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), matchingType, null);
+            await persister.GetSubscribers(matchingType);
+            await persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), matchingType, null);
             VerifyCache(persister.Cache);
         }
 
         [Test]
-        public void Unsubscribe_with_same_type_should_clear_cache()
+        public async Task Unsubscribe_with_same_type_should_clear_cache()
         {
-            var persister = SubscriptionTestHelper.CreateAzureSubscriptionStorage().AwaitFix();
+            var persister = await SubscriptionTestHelper.CreateAzureSubscriptionStorage();
             var matchingType = new MessageType("matchingType", new Version(0, 0, 0, 0));
-            persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), matchingType, null).AwaitFix();
-            persister.GetSubscribers(matchingType).AwaitFix();
-            persister.Unsubscribe(new Subscriber("address://test-queue", "endpoint"), matchingType, null).AwaitFix();
+            await persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), matchingType, null);
+            await persister.GetSubscribers(matchingType);
+            await persister.Unsubscribe(new Subscriber("address://test-queue", "endpoint"), matchingType, null);
             VerifyCache(persister.Cache);
         }
 
         [Test]
-        public void Unsubscribe_with_part_type_should_partially_clear_cache()
+        public async Task Unsubscribe_with_part_type_should_partially_clear_cache()
         {
-            var persister = SubscriptionTestHelper.CreateAzureSubscriptionStorage().AwaitFix();
+            var persister = await SubscriptionTestHelper.CreateAzureSubscriptionStorage();
             var version = new Version(0, 0, 0, 0);
             var type1 = new MessageType("type1", version);
             var type2 = new MessageType("type2", version);
             var type3 = new MessageType("type3", version);
-            persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type1, null).AwaitFix();
-            persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type2, null).AwaitFix();
-            persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type3, null).AwaitFix();
+            await persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type1, null);
+            await persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type2, null);
+            await persister.Subscribe(new Subscriber("address://test-queue", "endpoint"), type3, null);
 
-            persister.GetSubscribers(type1).AwaitFix();
-            persister.GetSubscribers(type2).AwaitFix();
-            persister.GetSubscribers(type3).AwaitFix();
-            persister.GetSubscribers(type1, type2).AwaitFix();
-            persister.GetSubscribers(type2, type3).AwaitFix();
-            persister.GetSubscribers(type1, type3).AwaitFix();
-            persister.GetSubscribers(type1, type2, type3).AwaitFix();
-            persister.Unsubscribe(new Subscriber("address://test-queue", "endpoint"), type2, null).AwaitFix();
+            await persister.GetSubscribers(type1);
+            await persister.GetSubscribers(type2);
+            await persister.GetSubscribers(type3);
+            await persister.GetSubscribers(type1, type2);
+            await persister.GetSubscribers(type2, type3);
+            await persister.GetSubscribers(type1, type3);
+            await persister.GetSubscribers(type1, type2, type3);
+            await persister.Unsubscribe(new Subscriber("address://test-queue", "endpoint"), type2, null);
             VerifyCache(persister.Cache);
         }
 


### PR DESCRIPTION
Now that Particular.Approvals is being used, the workaround to avoid using `async/await` in approval tests should no longer be required.