### PR TITLE
SDK Upgrade

### DIFF
--- a/src/NServiceBus.Persistence.AzureStorage/CloudTableExtensions.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/CloudTableExtensions.cs
@@ -5,8 +5,7 @@
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
 
     static class CloudTableExtensions
     {
@@ -35,7 +34,7 @@
                 {
                     items.AddRange(seg);
                 }
-            } 
+            }
             while (token != null && !ct.IsCancellationRequested && items.Count < take);
 
             return items;

--- a/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
+++ b/src/NServiceBus.Persistence.AzureStorage/NServiceBus.Persistence.AzureStorage.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.Storage" Version="[9.0.0, 10.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="[1.0.8, 2.0.0)" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="[12.6.0, 13.0.0)" />
     <PackageReference Include="NServiceBus" Version="8.0.0-alpha.627" />
     <PackageReference Include="Fody" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Persistence.AzureStorage/SafeLinqExtensions.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SafeLinqExtensions.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Persistence.AzureStorage
 {
     using System.Collections.Generic;
     using System.Linq;
-    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.Azure.Cosmos.Table;
 
     static class SafeLinqExtensions
     {

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
@@ -9,8 +9,7 @@
     using System.Threading.Tasks;
     using Extensibility;
     using Logging;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
     using Sagas;
     using SecondaryIndices;
 

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/AzureSagaPersister.cs
@@ -20,8 +20,16 @@
             this.autoUpdateSchema = autoUpdateSchema;
             var account = CloudStorageAccount.Parse(connectionString);
             client = account.CreateCloudTableClient();
+            isPremiumEndpoint = IsPremiumEndpoint(client);
 
             secondaryIndices = new SecondaryIndexPersister(GetTable, ScanForSaga, Persist, assumeSecondaryIndicesExist);
+        }
+
+        // the SDK uses exactly this method of changing the underlying executor
+        static bool IsPremiumEndpoint(CloudTableClient cloudTableClient)
+        {
+            var lowerInvariant = cloudTableClient.StorageUri.PrimaryUri.OriginalString.ToLowerInvariant();
+            return lowerInvariant.Contains("https://localhost") && cloudTableClient.StorageUri.PrimaryUri.Port != 10002 || lowerInvariant.Contains(".table.cosmosdb.") || lowerInvariant.Contains(".table.cosmos.");
         }
 
         public async Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context)
@@ -86,7 +94,8 @@
             {
                 ETag = etag,
                 PartitionKey = sagaId,
-                RowKey = sagaId
+                RowKey = sagaId,
+                WillBeStoredOnPremium = isPremiumEndpoint
             };
             try
             {
@@ -155,6 +164,10 @@
             try
             {
                 var tableEntity = (await table.ExecuteQueryAsync(query).ConfigureAwait(false)).SafeFirstOrDefault();
+                if (tableEntity != null)
+                {
+                    tableEntity.WillBeStoredOnPremium = isPremiumEndpoint;
+                }
                 return tableEntity;
             }
             catch (StorageException e) when(e.RequestInformation.HttpStatusCode == (int) HttpStatusCode.NotFound)
@@ -172,7 +185,7 @@
 
             var batch = new TableBatchOperation();
 
-            AddObjectToBatch(batch, saga, partitionKey, secondaryIndexKey, context);
+            AddObjectToBatch(batch, saga, partitionKey, secondaryIndexKey, context, isPremiumEndpoint);
 
             await table.ExecuteBatchAsync(batch).ConfigureAwait(false);
         }
@@ -203,7 +216,7 @@
             return entities.Select(entity => Guid.ParseExact(entity.PartitionKey, "D")).ToArray();
         }
 
-        static void AddObjectToBatch(TableBatchOperation batch, object entity, string partitionKey, PartitionRowKeyTuple? secondaryIndexKey, ContextBag context)
+        static void AddObjectToBatch(TableBatchOperation batch, object entity, string partitionKey, PartitionRowKeyTuple? secondaryIndexKey, ContextBag context, bool isPremiumEndpoint)
         {
             var rowkey = partitionKey;
 
@@ -223,12 +236,13 @@
             {
                 PartitionKey = partitionKey,
                 RowKey = rowkey,
-                ETag = etag
+                ETag = etag,
+                WillBeStoredOnPremium = isPremiumEndpoint
             }, properties);
 
             if (secondaryIndexKey != null)
             {
-                toPersist.Add(SecondaryIndexIndicatorProperty, secondaryIndexKey.ToString());
+                toPersist[SecondaryIndexIndicatorProperty] = EntityProperty.GeneratePropertyForString(secondaryIndexKey.ToString());
             }
 
             //no longer using InsertOrReplace as it ignores concurrency checks
@@ -247,6 +261,7 @@
         SecondaryIndexPersister secondaryIndices;
         const string SecondaryIndexIndicatorProperty = "NServiceBus_2ndIndexKey";
         static ConcurrentDictionary<string, bool> tableCreated = new ConcurrentDictionary<string, bool>();
+        private bool isPremiumEndpoint;
 
         /// <summary>
         /// Holds saga instance related metadata in a scope of a <see cref="ContextBag" />.

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntity.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntity.cs
@@ -3,8 +3,7 @@
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
 
     class DictionaryTableEntity : TableEntity, IDictionary<string, EntityProperty>
     {

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntity.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntity.cs
@@ -1,32 +1,22 @@
 ﻿namespace NServiceBus.Persistence.AzureStorage
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using Microsoft.Azure.Cosmos.Table;
 
-    class DictionaryTableEntity : TableEntity, IDictionary<string, EntityProperty>
+    class DictionaryTableEntity : TableEntity
     {
         public DictionaryTableEntity()
         {
             properties = new Dictionary<string, EntityProperty>();
         }
 
-        public void Add(string key, EntityProperty value)
-        {
-            properties.Add(key, value);
-        }
+        public bool WillBeStoredOnPremium { private get; set; }
+        public bool WasStoredOnPremium => !properties.ContainsKey("Id");
 
         public bool ContainsKey(string key)
         {
             return properties.ContainsKey(key);
-        }
-
-        public ICollection<string> Keys => properties.Keys;
-
-        public bool Remove(string key)
-        {
-            return properties.Remove(key);
         }
 
         public bool TryGetValue(string key, out EntityProperty value)
@@ -34,106 +24,28 @@
             return properties.TryGetValue(key, out value);
         }
 
-        public ICollection<EntityProperty> Values => properties.Values;
-
         public EntityProperty this[string key]
         {
             get { return properties[key]; }
             set { properties[key] = value; }
         }
 
-        public void Add(KeyValuePair<string, EntityProperty> item)
-        {
-            properties.Add(item);
-        }
-
-        public void Clear()
-        {
-            properties.Clear();
-        }
-
-        public bool Contains(KeyValuePair<string, EntityProperty> item)
-        {
-            return properties.Contains(item);
-        }
-
-        public void CopyTo(KeyValuePair<string, EntityProperty>[] array, int arrayIndex)
-        {
-            properties.CopyTo(array, arrayIndex);
-        }
-
-        public int Count => properties.Count;
-
-        public bool IsReadOnly => properties.IsReadOnly;
-
-        public bool Remove(KeyValuePair<string, EntityProperty> item)
-        {
-            return properties.Remove(item);
-        }
-
-        public IEnumerator<KeyValuePair<string, EntityProperty>> GetEnumerator()
-        {
-            return properties.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return properties.GetEnumerator();
-        }
-
         public override void ReadEntity(IDictionary<string, EntityProperty> entityProperties, OperationContext operationContext)
         {
             properties = entityProperties;
+            if (WasStoredOnPremium)
+            {
+                properties["Id"] = new EntityProperty(Guid.Parse(RowKey));
+            }
         }
 
         public override IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext)
         {
+            if (WillBeStoredOnPremium)
+            {
+                properties.Remove("Id");
+            }
             return properties;
-        }
-
-        public void Add(string key, bool value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, byte[] value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, DateTime? value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, DateTimeOffset? value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, double value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, Guid value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, int value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, long value)
-        {
-            properties.Add(key, new EntityProperty(value));
-        }
-
-        public void Add(string key, string value)
-        {
-            properties.Add(key, new EntityProperty(value));
         }
 
         IDictionary<string, EntityProperty> properties;

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntityExtensions.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/DictionaryTableEntityExtensions.cs
@@ -4,10 +4,9 @@ namespace NServiceBus.Persistence.AzureStorage
     using System.Collections.Generic;
     using System.IO;
     using System.Reflection;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
-    using EdmType = Microsoft.WindowsAzure.Storage.Table.EdmType;
 
     static class DictionaryTableEntityExtensions
     {

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/PartitionRowKeyTuple.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/PartitionRowKeyTuple.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Persistence.AzureStorage.SecondaryIndices
 {
     using System;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
 
     struct PartitionRowKeyTuple
     {

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexKeyBuilder.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexKeyBuilder.cs
@@ -4,8 +4,6 @@ namespace NServiceBus.Persistence.AzureStorage.SecondaryIndices
     using System.IO;
     using Newtonsoft.Json;
     using Sagas;
-    using System.Security.Cryptography;
-    using System.Text;
 
     static class SecondaryIndexKeyBuilder
     {
@@ -13,19 +11,7 @@ namespace NServiceBus.Persistence.AzureStorage.SecondaryIndices
         {
             var sagaDataTypeName = sagaType.FullName;
             var partitionKey = $"Index_{sagaDataTypeName}_{correlationProperty.Name}_{Serialize(correlationProperty.Value)}";
-            return new PartitionRowKeyTuple(partitionKey, DeterministicGuid(partitionKey).ToString());
-        }
-
-        static Guid DeterministicGuid(string src)
-        {
-            var stringBytes = Encoding.UTF8.GetBytes(src);
-
-            using (var sha1CryptoServiceProvider = new SHA1CryptoServiceProvider())
-            {
-                var hashedBytes = sha1CryptoServiceProvider.ComputeHash(stringBytes);
-                Array.Resize(ref hashedBytes, 16);
-                return new Guid(hashedBytes);
-            }
+            return new PartitionRowKeyTuple(partitionKey, partitionKey);
         }
 
         static string Serialize(object propertyValue)

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexPersister.cs
@@ -4,8 +4,7 @@
     using System.Net;
     using System.Threading.Tasks;
     using Extensibility;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
     using Sagas;
 
     class SecondaryIndexPersister

--- a/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexTableEntity.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/SagaPersisters/SecondaryIndices/SecondaryIndexTableEntity.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Persistence.AzureStorage.SecondaryIndices
 {
     using System;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
 
     // An entity holding information about the secondary index.
     class SecondaryIndexTableEntity : TableEntity

--- a/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureStorageSubscriptionPersistence.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureStorageSubscriptionPersistence.cs
@@ -3,8 +3,8 @@ namespace NServiceBus
     using System;
     using System.Threading.Tasks;
     using Features;
-    using Microsoft.WindowsAzure.Storage;
     using Logging;
+    using Microsoft.Azure.Cosmos.Table;
     using Microsoft.Extensions.DependencyInjection;
     using Persistence.AzureStorage.Config;
     using Unicast.Subscriptions;
@@ -19,7 +19,7 @@ namespace NServiceBus
 #pragma warning disable 618
             DependsOn<MessageDrivenSubscriptions>();
 #pragma warning restore 618
-            
+
             Defaults(s =>
             {
 #if NETFRAMEWORK

--- a/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureSubscriptionStorage.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Subscriptions/AzureSubscriptionStorage.cs
@@ -6,11 +6,9 @@
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.RetryPolicies;
-    using Microsoft.WindowsAzure.Storage.Table;
     using Extensibility;
     using MessageDrivenSubscriptions;
+    using Microsoft.Azure.Cosmos.Table;
     using Persistence.AzureStorage;
 
     class AzureSubscriptionStorage : ISubscriptionStorage

--- a/src/NServiceBus.Persistence.AzureStorage/Subscriptions/Subscription.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Subscriptions/Subscription.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Unicast.Subscriptions
 {
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
 
     class Subscription : TableEntity
     {

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureStorageTimeoutPersistence.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/AzureStorageTimeoutPersistence.cs
@@ -2,11 +2,12 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
-    using Persistence.AzureStorage;
+    using Azure.Storage.Blobs;
     using Features;
     using Logging;
+    using Microsoft.Azure.Cosmos.Table;
     using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.WindowsAzure.Storage;
+    using Persistence.AzureStorage;
     using Persistence.AzureStorage.Config;
     using Timeout.Core;
 
@@ -100,9 +101,8 @@ namespace NServiceBus
                 var timeoutManagerTable = cloudTableClient.GetTableReference(timeoutManagerDataTableName);
                 await timeoutManagerTable.CreateIfNotExistsAsync().ConfigureAwait(false);
 
-                var container = account.CreateCloudBlobClient()
-                    .GetContainerReference(timeoutStateContainerName);
-                await container.CreateIfNotExistsAsync().ConfigureAwait(false);
+                var cloudBlobClient = new BlobContainerClient(connectionString, timeoutStateContainerName);
+                await cloudBlobClient.CreateIfNotExistsAsync().ConfigureAwait(false);
             }
 
             protected override Task OnStop(IMessageSession session)

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutDataEntity.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutDataEntity.cs
@@ -1,11 +1,13 @@
 namespace NServiceBus.Persistence.AzureStorage
 {
     using System;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
 
     class TimeoutDataEntity : TableEntity
     {
-        public TimeoutDataEntity(){}
+        public TimeoutDataEntity()
+        {
+        }
 
         public TimeoutDataEntity(string partitionKey, string rowKey)
             : base(partitionKey, rowKey)

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutManagerDataEntity.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutManagerDataEntity.cs
@@ -2,8 +2,7 @@ namespace NServiceBus.Persistence.AzureStorage
 {
     using System;
     using System.Collections.Generic;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
 
     class TimeoutManagerDataEntity : TableEntity
     {

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutNextExecutionStrategy.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutNextExecutionStrategy.cs
@@ -10,11 +10,6 @@
 
         TimeSpan currentBackoff;
 
-        /// <summary>
-        /// </summary>
-        /// <param name="backoffIncrease">The amount of time to increase back-off each time.</param>
-        /// <param name="maximumBackoff">The maximum amount of time to back-off.</param>
-        /// <param name="currentDateTimeInUtc">Current DateTime.NowUtc generator.</param>
         public TimeoutNextExecutionStrategy(TimeSpan backoffIncrease, TimeSpan maximumBackoff, Func<DateTime> currentDateTimeInUtc)
         {
             this.backoffIncrease = backoffIncrease;

--- a/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
+++ b/src/NServiceBus.Persistence.AzureStorage/Timeout/TimeoutLogic/TimeoutPersister.cs
@@ -21,7 +21,6 @@
         {
             this.timeoutDataTableName = timeoutDataTableName;
             this.timeoutManagerDataTableName = timeoutManagerDataTableName;
-            this.timeoutStateContainerName = timeoutStateContainerName;
             this.catchUpInterval = catchUpInterval;
             this.partitionKeyScope = partitionKeyScope;
             this.endpointName = endpointName;
@@ -406,7 +405,7 @@
             var result = await table.ExecuteAsync(operation)
                 .ConfigureAwait(false);
 
-            //Concurrency Exception - PreCondition Failed or Entity Already Exists
+            // Concurrency Exception - PreCondition Failed or Entity Already Exists
             var statusCode = result.HttpStatusCode;
             if (statusCode == (int)HttpStatusCode.PreconditionFailed || statusCode == (int)HttpStatusCode.Conflict || statusCode == (int)HttpStatusCode.NoContent)
             {
@@ -444,7 +443,6 @@
 
         string timeoutDataTableName;
         string timeoutManagerDataTableName;
-        string timeoutStateContainerName;
         int catchUpInterval;
         string partitionKeyScope;
         string endpointName;

--- a/src/Tests/AzureRequestRecorder.cs
+++ b/src/Tests/AzureRequestRecorder.cs
@@ -4,7 +4,7 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.Azure.Cosmos.Table;
 
     public class AzureRequestRecorder : IDisposable
     {

--- a/src/Tests/Sagas/SecondaryIndexKeyBuilderTests.cs
+++ b/src/Tests/Sagas/SecondaryIndexKeyBuilderTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Sagas
 {
+    using System;
     using System.Threading.Tasks;
     using SecondaryIndices;
     using NServiceBus.Sagas;
@@ -17,7 +18,7 @@
 
             var key = SecondaryIndexKeyBuilder.BuildTableKey(typeof(SagaData), new SagaCorrelationProperty(sagaProp.Name, id));
             Assert.AreEqual("Index_NServiceBus.Persistence.AzureStorage.ComponentTests.Sagas.SecondaryIndexKeyBuilderTests+SagaData_AdditionalId_\"C4D91B59-A407-4CDA-A689-60AA3C334699\"", key.PartitionKey);
-            Assert.AreEqual("", key.RowKey);
+            Assert.IsTrue(Guid.TryParse(key.RowKey, out _));
         }
 
         class TestSaga : Saga<SagaData>, IAmStartedByMessages<StartSagaMessage>

--- a/src/Tests/Sagas/SecondaryIndexKeyBuilderTests.cs
+++ b/src/Tests/Sagas/SecondaryIndexKeyBuilderTests.cs
@@ -17,8 +17,9 @@
             metadata.TryGetCorrelationProperty(out var sagaProp);
 
             var key = SecondaryIndexKeyBuilder.BuildTableKey(typeof(SagaData), new SagaCorrelationProperty(sagaProp.Name, id));
-            Assert.AreEqual("Index_NServiceBus.Persistence.AzureStorage.ComponentTests.Sagas.SecondaryIndexKeyBuilderTests+SagaData_AdditionalId_\"C4D91B59-A407-4CDA-A689-60AA3C334699\"", key.PartitionKey);
-            Assert.IsTrue(Guid.TryParse(key.RowKey, out _));
+            var expected = "Index_NServiceBus.Persistence.AzureStorage.ComponentTests.Sagas.SecondaryIndexKeyBuilderTests+SagaData_AdditionalId_\"C4D91B59-A407-4CDA-A689-60AA3C334699\"";
+            Assert.AreEqual(expected, key.PartitionKey);
+            Assert.AreEqual(expected, key.RowKey);
         }
 
         class TestSaga : Saga<SagaData>, IAmStartedByMessages<StartSagaMessage>

--- a/src/Tests/Sagas/When_executing_concurrently.cs
+++ b/src/Tests/Sagas/When_executing_concurrently.cs
@@ -4,8 +4,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Extensibility;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
     using NServiceBus.Sagas;
     using NUnit.Framework;
 
@@ -30,11 +29,33 @@
             persister2 = new AzureSagaPersister(connectionString, true);
 
             // clear whole table
-            var entities = await cloudTable.ExecuteQueryAsync(new TableQuery<TableEntity>()).ConfigureAwait(false);
-            foreach (var te in entities)
+            var query = cloudTable.CreateQuery<TableEntity>();
+            var runningQuery = new TableQuery<DynamicTableEntity>()
             {
-                await cloudTable.DeleteIgnoringNotFound(te).ConfigureAwait(false);
+                FilterString = query.FilterString,
+                SelectColumns = query.SelectColumns
+            };
+            TableContinuationToken token = null;
+            var batchOperation = new TableBatchOperation();
+            do
+            {
+                runningQuery.TakeCount = query.TakeCount - batchOperation.Count;
+
+                var seg = await cloudTable.ExecuteQuerySegmentedAsync(runningQuery, token);
+                token = seg.ContinuationToken;
+                foreach (var entity in seg)
+                {
+                    var tableEntity = new DynamicTableEntity(entity.PartitionKey, entity.RowKey)
+                    {
+                        ETag = "*"
+                    };
+                    batchOperation.Add(TableOperation.Delete(tableEntity));
+                }
+
             }
+            while (token != null && (query.TakeCount == null || batchOperation.Count < query.TakeCount.Value));
+
+            await cloudTable.ExecuteBatchAsync(batchOperation).ConfigureAwait(false);
         }
 
         [Test(Description = "The test covering a scenario, when a secondary index wasn't deleted properly")]

--- a/src/Tests/Sagas/When_saving_saga.cs
+++ b/src/Tests/Sagas/When_saving_saga.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using Extensibility;
-    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.Azure.Cosmos.Table;
     using NUnit.Framework;
 
     public class When_saving_saga

--- a/src/Tests/Sagas/When_storing_saga_with_non_primitive_values.cs
+++ b/src/Tests/Sagas/When_storing_saga_with_non_primitive_values.cs
@@ -4,9 +4,8 @@
     using System.IO;
     using System.Net;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Table;
     using Extensibility;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
     using NUnit.Framework;
 
     public class When_storing_saga_with_non_primitive_values
@@ -38,13 +37,13 @@
             Assert.AreEqual(nullableDouble, sagaData.NullableDouble);
 
             // assert structure
-            var entity = await GetEntity(saga.Id);
+            var entity = GetEntity(saga.Id);
             var nullableDoubleProp = entity[nameof(NonPrimitiveSerializableSagaData.NullableDouble)];
             Assert.AreEqual(EdmType.Double, nullableDoubleProp.PropertyType);
             Assert.AreEqual(nullableDouble, nullableDoubleProp.DoubleValue);
         }
 
-        static async Task<DictionaryTableEntity> GetEntity(Guid sagaId)
+        static DictionaryTableEntity GetEntity(Guid sagaId)
         {
             var tableName = typeof(NonPrimitiveSerializableSagaData).Name;
             var account = CloudStorageAccount.Parse(Testing.Utillities.GetEnvConfiguredConnectionStringForPersistence());
@@ -54,7 +53,7 @@
 
             try
             {
-                var tableEntity = (await table.ExecuteQueryAsync(query).ConfigureAwait(false)).SafeFirstOrDefault();
+                var tableEntity = table.ExecuteQuery(query).SafeFirstOrDefault();
                 return tableEntity;
             }
             catch (StorageException e)

--- a/src/Tests/Subscriptions/SuscriptionTestHelper.cs
+++ b/src/Tests/Subscriptions/SuscriptionTestHelper.cs
@@ -2,8 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Microsoft.Azure.Cosmos.Table;
     using Unicast.Subscriptions;
 
     public class SubscriptionTestHelper

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -13,7 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.*" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="NServiceBus" Version="8.0.0-alpha.627" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/src/Tests/Timeouts/TestHelper.cs
+++ b/src/Tests/Timeouts/TestHelper.cs
@@ -1,3 +1,5 @@
+using Azure;
+
 namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
 {
     using System;
@@ -5,10 +7,8 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Blob;
-    using Microsoft.WindowsAzure.Storage.RetryPolicies;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Azure.Storage.Blobs;
+    using Microsoft.Azure.Cosmos.Table;
     using Support;
     using Timeout.Core;
     using NUnit.Framework;
@@ -102,40 +102,56 @@ namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
                 "Destination"
             });
 
-            // Define an entity resolver to work with the entity after retrieval.
-            EntityResolver<Tuple<string, string>> resolver = (pk, rk, ts, props, etag) => props.ContainsKey("Destination") ? new Tuple<string, string>(pk, rk) : null;
-
-            foreach (var tuple in await table.ExecuteQuerySegmentedAsync(
-                query: projectionQuery,
-                resolver: resolver,
-                token: null))
+            var runningQuery = new TableQuery<DynamicTableEntity>()
             {
-                var tableEntity = new DynamicTableEntity(tuple.Item1, tuple.Item2)
+                FilterString = projectionQuery.FilterString,
+                SelectColumns = projectionQuery.SelectColumns
+            };
+            TableContinuationToken token = null;
+            var operationCount = 0;
+            do
+            {
+                runningQuery.TakeCount = projectionQuery.TakeCount - operationCount;
+
+                var seg = await table.ExecuteQuerySegmentedAsync(runningQuery, token);
+                token = seg.ContinuationToken;
+                foreach (var entity in seg)
                 {
-                    ETag = "*"
-                };
-                await table.ExecuteAsync(TableOperation.Delete(tableEntity));
+                    var tableEntity = new DynamicTableEntity(entity.PartitionKey, entity.RowKey)
+                    {
+                        ETag = "*"
+                    };
+                    await table.ExecuteAsync(TableOperation.Delete(tableEntity));
+                    operationCount++;
+                }
+
             }
+            while (token != null && (projectionQuery.TakeCount == null || operationCount < projectionQuery.TakeCount.Value));
         }
 
         static async Task RemoveAllBlobs()
         {
-            var cloudStorageAccount = CloudStorageAccount.Parse(Testing.Utillities.GetEnvConfiguredConnectionStringForPersistence());
-            var container = cloudStorageAccount.CreateCloudBlobClient().GetContainerReference("timeoutstate");
-            await container.CreateIfNotExistsAsync();
-            foreach (var blob in (await container.ListBlobsSegmentedAsync(null)).Results)
+            // TODO: Check if this works
+            var connectionString = Testing.Utillities.GetEnvConfiguredConnectionStringForPersistence();
+            var blobContainerClient = new BlobContainerClient(connectionString, "timeoutstate");
+            await blobContainerClient.DeleteIfExistsAsync();
+
+            int attempt = 0;
+            RequestFailedException exception;
+            do
             {
-                var cloudBlob = (ICloudBlob)blob;
-                var requestOptions = new BlobRequestOptions
+                try
                 {
-                    RetryPolicy = new ExponentialRetry(TimeSpan.FromSeconds(15), 5)
-                };
-                await cloudBlob.DeleteAsync(
-                    deleteSnapshotsOption: DeleteSnapshotsOption.None,
-                    accessCondition: AccessCondition.GenerateEmptyCondition(),
-                    options: requestOptions,
-                    operationContext: null);
+                    await blobContainerClient.CreateIfNotExistsAsync();
+                    exception = null;
+                }
+                catch (RequestFailedException e) when (e.Status == 409 || e.ErrorCode == "ContainerBeingDeleted")
+                {
+                    exception = e;
+                    await Task.Delay(attempt++ * 1000);
+                }
             }
+            while (exception != null);
         }
     }
 }

--- a/src/Tests/Timeouts/TestHelper.cs
+++ b/src/Tests/Timeouts/TestHelper.cs
@@ -1,6 +1,3 @@
-using Azure;
-using Azure.Storage.Blobs.Models;
-
 namespace NServiceBus.Persistence.AzureStorage.ComponentTests.Timeouts
 {
     using System;


### PR DESCRIPTION
Support for

- Microsoft.Azure.Cosmos.Table
- Azure.Storage.Blobs

This is the first step in support the Cosmos Table API. In order to make sure when secondary indices are used those entries are compatible with Cosmos DB the partition key value is also propagated to the row key. For people migrating from Azure Storage using 2.4 or earlier they need to make sure the data imported will be using the partition key as a row key so that the document id underneath is properly assigned (due to Cosmos DB table API assuming row key = doc id)