### PR TITLE
Saga entity to table entity mapping with expression tree per property

### DIFF
--- a/src/NServiceBus.Persistence.AzureTable/SagaPersisters/AzureSagaPersister.cs
+++ b/src/NServiceBus.Persistence.AzureTable/SagaPersisters/AzureSagaPersister.cs
@@ -4,7 +4,6 @@
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Net;
-    using System.Reflection;
     using System.Threading.Tasks;
     using Extensibility;
     using Microsoft.Azure.Cosmos.Table;
@@ -27,12 +26,11 @@
             var partitionKey = GetPartitionKey(context, sagaData.Id);
             var sagaDataType = sagaData.GetType();
 
-            var properties = SelectPropertiesToPersist(sagaDataType);
             var sagaDataEntityToSave = DictionaryTableEntityExtensions.ToDictionaryTableEntity(sagaData, new DictionaryTableEntity
             {
                 PartitionKey = partitionKey.PartitionKey,
                 RowKey = sagaData.Id.ToString(),
-            }, properties);
+            });
 
             var table = await GetTableAndCreateIfNotExists(storageSession, sagaDataType)
                 .ConfigureAwait(false);
@@ -56,9 +54,7 @@
             var meta = context.GetOrCreate<SagaInstanceMetadata>();
             var sagaDataEntityToUpdate = meta.Entities[sagaData];
 
-            var properties = SelectPropertiesToPersist(sagaDataType);
-
-            var sagaAsDictionaryTableEntity = DictionaryTableEntityExtensions.ToDictionaryTableEntity(sagaData, sagaDataEntityToUpdate, properties);
+            var sagaAsDictionaryTableEntity = DictionaryTableEntityExtensions.ToDictionaryTableEntity(sagaData, sagaDataEntityToUpdate);
 
             storageSession.Add(new SagaUpdate(partitionKey, sagaAsDictionaryTableEntity));
 
@@ -189,11 +185,6 @@
                 storageSession.Add(new SagaRemoveSecondaryIndex(tableEntityPartitionKey, sagaData.Id, secondaryIndices, partitionRowKeyTuple.Value, sagaDataEntityToDelete.Table));
             }
             return Task.CompletedTask;
-        }
-
-        internal static PropertyInfo[] SelectPropertiesToPersist(Type sagaType)
-        {
-            return sagaType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         }
 
         static TableEntityPartitionKey GetPartitionKey(ContextBag context, Guid sagaDataId)

--- a/src/NServiceBus.Persistence.AzureTable/SagaPersisters/AzureSagaPersister.cs
+++ b/src/NServiceBus.Persistence.AzureTable/SagaPersisters/AzureSagaPersister.cs
@@ -49,8 +49,6 @@
             var storageSession = (StorageSession)session;
             var partitionKey = GetPartitionKey(context, sagaData.Id);
 
-            var sagaDataType = sagaData.GetType();
-
             var meta = context.GetOrCreate<SagaInstanceMetadata>();
             var sagaDataEntityToUpdate = meta.Entities[sagaData];
 
@@ -86,7 +84,7 @@
 
             readSagaDataEntity.Table = tableToReadFrom;
 
-            var sagaData = DictionaryTableEntityExtensions.ToEntity<TSagaData>(readSagaDataEntity);
+            var sagaData = DictionaryTableEntityExtensions.ToSagaData<TSagaData>(readSagaDataEntity);
             var meta = context.GetOrCreate<SagaInstanceMetadata>();
             meta.Entities[sagaData] = readSagaDataEntity;
             return sagaData;

--- a/src/NServiceBus.Persistence.AzureTable/SagaPersisters/DictionaryTableEntityExtensions.cs
+++ b/src/NServiceBus.Persistence.AzureTable/SagaPersisters/DictionaryTableEntityExtensions.cs
@@ -254,8 +254,8 @@ namespace NServiceBus.Persistence.AzureTable
             return query;
         }
 
-        static readonly ConcurrentDictionary<Type, IEnumerable<GetAccessor>> getterCache = new ConcurrentDictionary<Type, IEnumerable<GetAccessor>>();
-        static readonly ConcurrentDictionary<Type, IEnumerable<SetAccessor>> setterCache = new ConcurrentDictionary<Type, IEnumerable<SetAccessor>>();
+        static readonly ConcurrentDictionary<Type, IReadOnlyCollection<GetAccessor>> getterCache = new ConcurrentDictionary<Type, IReadOnlyCollection<GetAccessor>>();
+        static readonly ConcurrentDictionary<Type, IReadOnlyCollection<SetAccessor>> setterCache = new ConcurrentDictionary<Type, IReadOnlyCollection<SetAccessor>>();
 
         static readonly JsonSerializer jsonSerializer = JsonSerializer.Create();
         static readonly JsonSerializer jsonSerializerWithNonAbstractDefaultContractResolver = new JsonSerializer


### PR DESCRIPTION
Attempt to make storing and loading table entities faster without being too invasive.

The warmup scenario in the benchmark does make sure to have the expression tree precompiled. 
The test scenario tests a [full roundtrip](https://github.com/danielmarbach/MicroBenchmarks/commit/590dff1699086b943103d4a85770ee387b83fca2).

## Complex state mapping

The majority of the cost occurs when serialization with JSON the `IntArray` and `ComplexData` property. Still the improvements are very nice.

```
public class ComplexStateSagaData
{
    public Guid Id { get; set; }
    public string Originator { get; set; }
    public string OriginalMessageId { get; set; }
    public Guid SomeId { get; set; }

    public int[] IntArray { get; set; }
    public double? NullableDouble { get; set; }

    public bool? NullableBool { get; set; }
    public int? NullableInt { get; set; }
    public Guid? NullableGuid { get; set; }
    public long? NullableLong { get; set; }
    public byte[] ByteArray { get; set; }

    public SomethingComplex ComplexData { get; set; }
}

public class SomethingComplex
{
    public string Data { get; set; }
}
```

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
AMD Ryzen Threadripper 1920X, 1 CPU, 24 logical and 12 physical cores
.NET Core SDK=3.1.402
  [Host]   : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  ShortRun : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
|        Method | Calls | Warmup |         Mean |         Error |     StdDev | Ratio | RatioSD |     Gen 0 | Gen 1 | Gen 2 |  Allocated |
|-------------- |------ |------- |-------------:|--------------:|-----------:|------:|--------:|----------:|------:|------:|-----------:|
| **MappingBefore** |     **1** |  **False** |     **19.37 μs** |      **2.351 μs** |   **0.129 μs** |  **1.00** |    **0.00** |    **2.3499** |     **-** |     **-** |    **9.65 KB** |
|  MappingAfter |     1 |  False |     12.04 μs |      0.300 μs |   0.016 μs |  0.62 |    0.00 |    2.0599 |     - |     - |    8.47 KB |
|               |       |        |              |               |            |       |         |           |       |       |            |
| **MappingBefore** |     **1** |   **True** |     **18.81 μs** |     **13.943 μs** |   **0.764 μs** |  **1.00** |    **0.00** |    **2.3499** |     **-** |     **-** |    **9.65 KB** |
|  MappingAfter |     1 |   True |     12.06 μs |      2.893 μs |   0.159 μs |  0.64 |    0.02 |    2.0599 |     - |     - |    8.47 KB |
|               |       |        |              |               |            |       |         |           |       |       |            |
| **MappingBefore** |    **20** |  **False** |    **384.73 μs** |    **130.293 μs** |   **7.142 μs** |  **1.00** |    **0.00** |   **46.8750** |     **-** |     **-** |  **192.97 KB** |
|  MappingAfter |    20 |  False |    251.28 μs |     80.108 μs |   4.391 μs |  0.65 |    0.02 |   41.2598 |     - |     - |  169.38 KB |
|               |       |        |              |               |            |       |         |           |       |       |            |
| **MappingBefore** |    **20** |   **True** |    **397.50 μs** |     **71.495 μs** |   **3.919 μs** |  **1.00** |    **0.00** |   **46.8750** |     **-** |     **-** |  **192.97 KB** |
|  MappingAfter |    20 |   True |    234.01 μs |     32.694 μs |   1.792 μs |  0.59 |    0.01 |   41.2598 |     - |     - |  169.38 KB |
|               |       |        |              |               |            |       |         |           |       |       |            |
| **MappingBefore** |   **100** |  **False** |  **1,988.21 μs** |    **114.316 μs** |   **6.266 μs** |  **1.00** |    **0.00** |  **234.3750** |     **-** |     **-** |  **964.87 KB** |
|  MappingAfter |   100 |  False |  1,240.31 μs |    836.981 μs |  45.878 μs |  0.62 |    0.02 |  207.0313 |     - |     - |  846.88 KB |
|               |       |        |              |               |            |       |         |           |       |       |            |
| **MappingBefore** |   **100** |   **True** |  **1,973.35 μs** |    **101.718 μs** |   **5.575 μs** |  **1.00** |    **0.00** |  **234.3750** |     **-** |     **-** |  **964.84 KB** |
|  MappingAfter |   100 |   True |  1,165.61 μs |  1,403.911 μs |  76.953 μs |  0.59 |    0.04 |  207.0313 |     - |     - |  846.88 KB |
|               |       |        |              |               |            |       |         |           |       |       |            |
| **MappingBefore** |  **1000** |  **False** | **19,800.24 μs** |  **8,101.429 μs** | **444.067 μs** |  **1.00** |    **0.00** | **2343.7500** |     **-** |     **-** | **9649.11 KB** |
|  MappingAfter |  1000 |  False | 12,391.40 μs |    111.296 μs |   6.101 μs |  0.63 |    0.01 | 2062.5000 |     - |     - | 8468.89 KB |
|               |       |        |              |               |            |       |         |           |       |       |            |
| **MappingBefore** |  **1000** |   **True** | **19,196.84 μs** | **14,021.205 μs** | **768.550 μs** |  **1.00** |    **0.00** | **2343.7500** |     **-** |     **-** | **9648.44 KB** |
|  MappingAfter |  1000 |   True | 12,718.04 μs |  5,916.252 μs | 324.290 μs |  0.66 |    0.02 | 2062.5000 |     - |     - | 8468.75 KB |

## Simple state mapping

Here there is no complex state that needs to be serialized to string. All the types are natively supported. The new approach really shines here. 

```
public class SimpleStateSagaData
{
    public Guid Id { get; set; }
    public string Originator { get; set; }
    public string OriginalMessageId { get; set; }
    public Guid SomeId { get; set; }

    public double? NullableDouble { get; set; }

    public bool? NullableBool { get; set; }
    public int? NullableInt { get; set; }
    public Guid? NullableGuid { get; set; }
    public long? NullableLong { get; set; }
    public byte[] ByteArray { get; set; }

}
```

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
AMD Ryzen Threadripper 1920X, 1 CPU, 24 logical and 12 physical cores
.NET Core SDK=3.1.402
  [Host]  : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  LongRun : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT

Job=LongRun  IterationCount=100  LaunchCount=3  
WarmupCount=15  

```
|        Method | Calls | Warmup |          Mean |      Error |      StdDev |        Median | Ratio |    Gen 0 | Gen 1 | Gen 2 |  Allocated |
|-------------- |------ |------- |--------------:|-----------:|------------:|--------------:|------:|---------:|------:|------:|-----------:|
| **MappingBefore** |     **1** |  **False** |     **10.189 μs** |  **0.0306 μs** |   **0.1555 μs** |     **10.168 μs** |  **1.00** |   **0.7629** |     **-** |     **-** |    **3.16 KB** |
|  MappingAfter |     1 |  False |      4.691 μs |  0.0164 μs |   0.0840 μs |      4.714 μs |  0.46 |   0.5188 |     - |     - |    2.14 KB |
|               |       |        |               |            |             |               |       |          |       |       |            |
| **MappingBefore** |     **1** |   **True** |     **10.677 μs** |  **0.0243 μs** |   **0.1228 μs** |     **10.719 μs** |  **1.00** |   **0.7629** |     **-** |     **-** |    **3.16 KB** |
|  MappingAfter |     1 |   True |      4.651 μs |  0.0191 μs |   0.0983 μs |      4.654 μs |  0.44 |   0.5188 |     - |     - |    2.14 KB |
|               |       |        |               |            |             |               |       |          |       |       |            |
| **MappingBefore** |    **20** |  **False** |    **200.934 μs** |  **0.1414 μs** |   **0.6986 μs** |    **200.884 μs** |  **1.00** |  **15.3809** |     **-** |     **-** |   **63.28 KB** |
|  MappingAfter |    20 |  False |     90.932 μs |  0.5054 μs |   2.5708 μs |     90.117 μs |  0.45 |  10.3760 |     - |     - |   42.81 KB |
|               |       |        |               |            |             |               |       |          |       |       |            |
| **MappingBefore** |    **20** |   **True** |    **209.014 μs** |  **0.7050 μs** |   **3.6553 μs** |    **209.327 μs** |  **1.00** |  **15.3809** |     **-** |     **-** |   **63.28 KB** |
|  MappingAfter |    20 |   True |     92.246 μs |  0.2853 μs |   1.4303 μs |     92.268 μs |  0.44 |  10.3760 |     - |     - |   42.81 KB |
|               |       |        |               |            |             |               |       |          |       |       |            |
| **MappingBefore** |   **100** |  **False** |  **1,027.018 μs** |  **4.3176 μs** |  **22.2714 μs** |  **1,028.506 μs** |  **1.00** |  **77.1484** |     **-** |     **-** |  **316.42 KB** |
|  MappingAfter |   100 |  False |    468.387 μs |  1.2530 μs |   6.4410 μs |    469.527 μs |  0.46 |  52.2461 |     - |     - |  214.06 KB |
|               |       |        |               |            |             |               |       |          |       |       |            |
| **MappingBefore** |   **100** |   **True** |  **1,053.909 μs** |  **2.7463 μs** |  **14.2398 μs** |  **1,053.955 μs** |  **1.00** |  **76.1719** |     **-** |     **-** |  **316.41 KB** |
|  MappingAfter |   100 |   True |    469.171 μs |  2.4167 μs |  12.4009 μs |    475.261 μs |  0.45 |  52.2461 |     - |     - |  214.06 KB |
|               |       |        |               |            |             |               |       |          |       |       |            |
| **MappingBefore** |  **1000** |  **False** | **10,553.155 μs** | **39.8895 μs** | **204.3290 μs** | **10,564.624 μs** |  **1.00** | **765.6250** |     **-** |     **-** | **3164.22 KB** |
|  MappingAfter |  1000 |  False |  4,824.904 μs | 17.1272 μs |  88.9586 μs |  4,822.073 μs |  0.46 | 523.4375 |     - |     - | 2140.63 KB |
|               |       |        |               |            |             |               |       |          |       |       |            |
| **MappingBefore** |  **1000** |   **True** | **10,392.290 μs** | **41.4193 μs** | **212.1651 μs** | **10,408.375 μs** |  **1.00** | **765.6250** |     **-** |     **-** | **3164.06 KB** |
|  MappingAfter |  1000 |   True |  4,676.764 μs |  6.2283 μs |  32.0158 μs |  4,674.052 μs |  0.45 | 523.4375 |     - |     - | 2140.63 KB |
