### PR TITLE
Make sure sagas work under CompatibilityMode with CosmosDB even if AssumeSecondaryKeyUsesANonEmptyRowKeySetToThePartitionKey was not called

### DIFF
--- a/src/NServiceBus.Persistence.AzureTable/SagaPersisters/SecondaryIndices/SecondaryIndex.cs
+++ b/src/NServiceBus.Persistence.AzureTable/SagaPersisters/SecondaryIndices/SecondaryIndex.cs
@@ -3,7 +3,9 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Threading.Tasks;
+    using Logging;
     using Microsoft.Azure.Cosmos.Table;
     using Sagas;
 
@@ -27,15 +29,30 @@
             }
 
             var rowKey = assumeSecondaryKeyUsesANonEmptyRowKeySetToThePartitionKey ? key.PartitionKey : key.RowKey;
-            var exec = await table.ExecuteAsync(TableOperation.Retrieve<SecondaryIndexTableEntity>(key.PartitionKey, rowKey))
-                .ConfigureAwait(false);
+
+            TableResult exec;
+            try
+            {
+                exec = await table.ExecuteAsync(TableOperation.Retrieve<SecondaryIndexTableEntity>(key.PartitionKey, rowKey))
+                    .ConfigureAwait(false);
+            }
+            catch (StorageException storageException)
+                when(!assumeSecondaryKeyUsesANonEmptyRowKeySetToThePartitionKey && storageException.RequestInformation.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed)
+            {
+                Logger.Warn(
+                    $"Trying to retrieve the secondary index entry with PartitionKey = '{key.PartitionKey}' and RowKey = 'string.Empty' failed. When using the compatibility mode on Azure Cosmos DB it is strongly recommended to enable `sagaPersistence.AssumeSecondaryKeyUsesANonEmptyRowKeySetToThePartitionKey()` to avoid additional lookup costs or disable the compatibility mode entirely if not needed by calling `persistence.Compatibility().DisableSecondaryKeyLookupForSagasCorrelatedByProperties(). Falling back to query secondary index entry with PartitionKey = '{key.PartitionKey}' and RowKey = '{key.PartitionKey}'",
+                    storageException);
+
+                exec = await table.ExecuteAsync(TableOperation.Retrieve<SecondaryIndexTableEntity>(key.PartitionKey, key.PartitionKey))
+                    .ConfigureAwait(false);
+            }
             if (exec.Result is SecondaryIndexTableEntity secondaryIndexEntry)
             {
                 cache.Put(key, secondaryIndexEntry.SagaId);
                 return secondaryIndexEntry.SagaId;
             }
 
-            if (assumeSecondaryIndicesExist)
+            if (assumeSecondaryIndicesExist || exec.Result is null)
             {
                 return null;
             }
@@ -97,5 +114,6 @@
         private readonly bool assumeSecondaryIndicesExist;
         private readonly bool assumeSecondaryKeyUsesANonEmptyRowKeySetToThePartitionKey;
         const int LRUCapacity = 1000;
+        private static readonly ILog Logger = LogManager.GetLogger<SecondaryIndex>();
     }
 }

--- a/src/NServiceBus.Persistence.AzureTable/SagaPersisters/SecondaryIndices/SecondaryIndex.cs
+++ b/src/NServiceBus.Persistence.AzureTable/SagaPersisters/SecondaryIndices/SecondaryIndex.cs
@@ -52,7 +52,7 @@
                 return secondaryIndexEntry.SagaId;
             }
 
-            if (assumeSecondaryIndicesExist || exec.Result is null)
+            if (assumeSecondaryIndicesExist)
             {
                 return null;
             }

--- a/src/Tests/Sagas/SecondaryIndexTests.cs
+++ b/src/Tests/Sagas/SecondaryIndexTests.cs
@@ -1,0 +1,83 @@
+namespace NServiceBus.Persistence.AzureTable.Tests
+{
+    using NUnit.Framework;
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Logging;
+    using Microsoft.Azure.Cosmos.Table;
+    using Sagas;
+    using Testing;
+
+    [TestFixture("CosmosDB")]
+    public class SecondaryIndexTests
+    {
+        public SecondaryIndexTests(string tableApiType)
+        {
+            this.tableApiType = tableApiType;
+        }
+
+        [SetUp]
+        public async Task SetUp()
+        {
+            logStatements = new StringBuilder();
+
+            var account = CloudStorageAccount.Parse(ConnectionStringHelper.GetEnvConfiguredConnectionStringForPersistence(tableApiType));
+
+            client = account.CreateCloudTableClient();
+            tableName = nameof(SecondaryIndexTests).ToLower();
+            cloudTable = client.GetTableReference(tableName);
+            await cloudTable.CreateIfNotExistsAsync();
+        }
+
+        [Test]
+        public async Task When_empty_row_key_should_log_warn_and_assume_row_key_partition_key()
+        {
+            var someId = new Guid("E57CF37C-1CBC-4B08-8C19-3FCE2FFC0451").ToString();
+
+            scope = LogManager.Use<TestingLoggerFactory>()
+                .BeginScope(new StringWriter(logStatements));
+
+            var secondaryIndex = new SecondaryIndex();
+
+            var result = await secondaryIndex.FindSagaId<TestSagaData>(cloudTable,
+                new SagaCorrelationProperty("SomeId", someId));
+
+            Assert.IsNull(result);
+            StringAssert.Contains("Trying to retrieve the secondary index entry with PartitionKey = 'Index_NServiceBus.Persistence.AzureTable.Tests.SecondaryIndexTests+TestSagaData_SomeId_\"e57cf37c-1cbc-4b08-8c19-3fce2ffc0451\"' and RowKey = 'string.Empty' failed", logStatements.ToString());
+        }
+
+        [Test]
+        public async Task When_opt_in_for_non_empty_row_key_should_not_log_warn()
+        {
+            var someId = new Guid("E57CF37C-1CBC-4B08-8C19-3FCE2FFC0451").ToString();
+
+            scope = LogManager.Use<TestingLoggerFactory>()
+                .BeginScope(new StringWriter(logStatements));
+
+            var secondaryIndex = new SecondaryIndex(assumeSecondaryKeyUsesANonEmptyRowKeySetToThePartitionKey: true);
+
+            var result = await secondaryIndex.FindSagaId<TestSagaData>(cloudTable,
+                new SagaCorrelationProperty("SomeId", someId));
+
+            Assert.IsNull(result);
+            Assert.IsEmpty(logStatements.ToString());
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            scope.Dispose();
+        }
+
+        class TestSagaData : ContainSagaData {}
+
+        StringBuilder logStatements;
+        IDisposable scope;
+        private CloudTable cloudTable;
+        private CloudTableClient client;
+        private string tableName;
+        private string tableApiType;
+    }
+}

--- a/src/Tests/Sagas/SecondaryIndexTests.cs
+++ b/src/Tests/Sagas/SecondaryIndexTests.cs
@@ -34,7 +34,7 @@ namespace NServiceBus.Persistence.AzureTable.Tests
         [Test]
         public async Task When_empty_row_key_should_log_warn_and_assume_row_key_partition_key()
         {
-            var someId = new Guid("E57CF37C-1CBC-4B08-8C19-3FCE2FFC0451").ToString();
+            var someId = new Guid("E57CF37C-1CBC-4B08-8C19-3FCE2FFC0451");
 
             scope = LogManager.Use<TestingLoggerFactory>()
                 .BeginScope(new StringWriter(logStatements));
@@ -51,7 +51,7 @@ namespace NServiceBus.Persistence.AzureTable.Tests
         [Test]
         public async Task When_opt_in_for_non_empty_row_key_should_not_log_warn()
         {
-            var someId = new Guid("E57CF37C-1CBC-4B08-8C19-3FCE2FFC0451").ToString();
+            var someId = new Guid("E57CF37C-1CBC-4B08-8C19-3FCE2FFC0451");
 
             scope = LogManager.Use<TestingLoggerFactory>()
                 .BeginScope(new StringWriter(logStatements));
@@ -71,7 +71,10 @@ namespace NServiceBus.Persistence.AzureTable.Tests
             scope.Dispose();
         }
 
-        class TestSagaData : ContainSagaData {}
+        class TestSagaData : ContainSagaData
+        {
+            public Guid SomeId { get; set; }
+        }
 
         StringBuilder logStatements;
         IDisposable scope;


### PR DESCRIPTION
Brings #334 to `release-3.0`