### PR TITLE
remove R# suppression

### DIFF
--- a/src/Compatibility.StorageTable.AcceptanceTests/Previous/SecondaryIndexPersister.cs
+++ b/src/Compatibility.StorageTable.AcceptanceTests/Previous/SecondaryIndexPersister.cs
@@ -81,8 +81,6 @@
 
                         throw new RetryNeededException();
                     }
-
-                    // ReSharper disable once RedundantIfElseBlock to make it visible for a reader
                     else
                     {
                         // data is null, this means that either the entry has been created as the secondary index after scanning the table or after storing the primary


### PR DESCRIPTION
Introduced here — https://github.com/Particular/NServiceBus.Persistence.AzureStorage/pull/311/files#diff-449453ffb3e1afd5b5844e2daf645d634a64bf83a508ac2f755efd572e486355R85

Note that we removed R# artifacts in https://github.com/Particular/NServiceBus.Persistence.AzureStorage/pull/296 as part of switching to StyleCop.