### PR TITLE
Make sure PendingTransportOperations clearing doesn't leak state from previous executions

### DIFF
--- a/src/NServiceBus.Persistence.AzureTable/Outbox/LogicalOutboxBehavior.cs
+++ b/src/NServiceBus.Persistence.AzureTable/Outbox/LogicalOutboxBehavior.cs
@@ -1,10 +1,7 @@
 ﻿namespace NServiceBus.Persistence.AzureTable
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Linq.Expressions;
-    using System.Reflection;
     using System.Threading.Tasks;
     using DelayedDelivery;
     using DeliveryConstraints;
@@ -20,20 +17,8 @@
     /// </summary>
     public sealed class LogicalOutboxBehavior : IBehavior<IIncomingLogicalMessageContext, IIncomingLogicalMessageContext>
     {
-        static LogicalOutboxBehavior()
-        {
-            var field = typeof(PendingTransportOperations).GetField("operations", BindingFlags.NonPublic | BindingFlags.Instance);
-            var targetExp = Expression.Parameter(typeof(PendingTransportOperations), "target");
-            var fieldExp = Expression.Field(targetExp, field);
-            var assignExp = Expression.Assign(fieldExp, Expression.Constant(new ConcurrentStack<TransportOperation>()));
-
-            setter = Expression.Lambda<Action<PendingTransportOperations>>(assignExp, targetExp).Compile();
-        }
-
-        internal LogicalOutboxBehavior(TableHolderResolver tableHolderResolver)
-        {
+        internal LogicalOutboxBehavior(TableHolderResolver tableHolderResolver) =>
             this.tableHolderResolver = tableHolderResolver;
-        }
 
         /// <inheritdoc />
         public async Task Invoke(IIncomingLogicalMessageContext context, Func<IIncomingLogicalMessageContext, Task> next)
@@ -87,7 +72,7 @@
             outboxTransaction.SuppressStoreAndCommit = true;
 
             var pendingTransportOperations = context.Extensions.Get<PendingTransportOperations>();
-            setter(pendingTransportOperations);
+            pendingTransportOperations.Clear();
 
             foreach (var operation in outboxRecord.Operations)
             {
@@ -142,7 +127,6 @@
             throw new Exception("Could not find routing strategy to deserialize.");
         }
 
-        static Action<PendingTransportOperations> setter;
         readonly TableHolderResolver tableHolderResolver;
     }
 }

--- a/src/NServiceBus.Persistence.AzureTable/Outbox/PendingTransportOperationsExtensions.cs
+++ b/src/NServiceBus.Persistence.AzureTable/Outbox/PendingTransportOperationsExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.Persistence.AzureTable
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using Transport;
+
+    static class PendingTransportOperationsExtensions
+    {
+        static PendingTransportOperationsExtensions()
+        {
+            var field = typeof(PendingTransportOperations).GetField("operations",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var targetExp = Expression.Parameter(typeof(PendingTransportOperations), "target");
+            var fieldExp = Expression.Field(targetExp, field);
+            getter = Expression
+                .Lambda<Func<PendingTransportOperations, ConcurrentStack<TransportOperation>>>(fieldExp, targetExp)
+                .Compile();
+        }
+
+        public static void Clear(this PendingTransportOperations operations)
+        {
+            var collection = getter(operations);
+            collection.Clear();
+        }
+
+        static readonly Func<PendingTransportOperations, ConcurrentStack<TransportOperation>> getter;
+    }
+}

--- a/src/Tests/Outbox/PendingTransportOperationsExtensionsTests.cs
+++ b/src/Tests/Outbox/PendingTransportOperationsExtensionsTests.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.Persistence.AzureTable.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using Routing;
+    using Transport;
+
+    [TestFixture]
+    public class PendingTransportOperationsExtensionsTests
+    {
+        [Test]
+        public void Should_clear_existing_operations()
+        {
+            var operations = new PendingTransportOperations();
+            operations.Add(new TransportOperation(
+                new OutgoingMessage("", new Dictionary<string, string>(), Array.Empty<byte>()),
+                new UnicastAddressTag("someQueue")));
+
+            operations.Clear();
+
+            Assert.That(operations.Operations, Is.Empty);
+        }
+
+        [Test]
+        public void Should_support_adding_after_clearing()
+        {
+            var operations = new PendingTransportOperations();
+            operations.Add(new TransportOperation(
+                new OutgoingMessage("1", new Dictionary<string, string>(), Array.Empty<byte>()),
+                new UnicastAddressTag("someQueue")));
+
+            operations.Clear();
+
+            operations.Add(new TransportOperation(
+                new OutgoingMessage("2", new Dictionary<string, string>(), Array.Empty<byte>()),
+                new UnicastAddressTag("someQueue")));
+
+            operations.Clear();
+
+            operations.Add(new TransportOperation(
+                new OutgoingMessage("3", new Dictionary<string, string>(), Array.Empty<byte>()),
+                new UnicastAddressTag("someQueue")));
+
+            Assert.That(operations.Operations, Has.Length.EqualTo(1));
+        }
+    }
+}


### PR DESCRIPTION
Backport of #579 for the `release-3.1` branch